### PR TITLE
What if `Vector`, but `.objects` is `tuple`?

### DIFF
--- a/src/flitter/model.pxd
+++ b/src/flitter/model.pxd
@@ -5,7 +5,7 @@ import cython
 
 cdef class Vector:
     cdef int length
-    cdef list objects
+    cdef tuple objects
     cdef double* numbers
     cdef double[16] _numbers
     cdef unsigned long long _hash


### PR DESCRIPTION
Since `Vector` objects are supposed to be immutable, I can make the `.objects` sequence a `tuple` instead of a `list`. This is useful because there are a number of optimisations in the Python runtime for creating tuples more cheaply than lists.