### PR TITLE
Add 3D solid model operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -101,15 +101,16 @@ The first-level runtime dependencies are:
 - `lark` - for the language parser
 - `loguru` - for enhanced logging
 - `mako` - for templating of the GLSL source
-- `manifold3d` - for 3D mesh boolean operations
+- `manifold3d` - used by `trimesh` for 3D mesh boolean operations
 - `moderngl` - for a higher-level API to OpenGL
+- `networkx` - used by `trimesh` for some 3D mesh operations
 - `numpy` - for fast memory crunching
 - `pillow` - for saving screenshots as image files
 - `pyserial` - for talking to DMX interfaces
 - `pyusb` - for low-level communication with the Push 2 and LaserCube
 - `regex` - used by `lark` for advanced regular expressions
 - `rtmidi2` - for talking MIDI to control surfaces
-- `scipy` - for some 3D mesh operations
+- `scipy` - used by `trimesh` for some 3D mesh operations
 - `skia-python` - for 2D drawing
 - `trimesh` - for loading 3D meshes
 

--- a/README.md
+++ b/README.md
@@ -7,9 +7,9 @@ with trails moving outwards from the centre of the screen.](docs/header.jpg)
 system for describing 2D and 3D visuals. [The language](/docs/language.md) is
 designed to encourage an iterative, explorative, play-based approach to
 constructing generative visuals. The engine that runs **Flitter** programs is
-able to live reload all code and assets while retaining current system state
-(thus supporting live-coding) while also having strong support for interacting
-with running programs via MIDI surfaces.
+able to live reload all code (including shaders) and assets (images, models,
+etc.) while retaining current system state - thus supporting live-coding. It
+also has support for interacting with running programs via MIDI surfaces.
 
 **Flitter** is designed for expressivity and ease of engine development over
 raw performance, but is sufficiently fast to be able to do interesting things.
@@ -17,22 +17,31 @@ raw performance, but is sufficiently fast to be able to do interesting things.
 The engine that runs the language is capable of:
 
 - 2D drawing (loosely based on an HTML canvas/SVG model)
-- 3D rendering of primitive shapes and external triangular mesh models (in a
-variety of formats including OBJ and STL); ambient, directional, point and
-spot- light sources with (currently shadowless) [PBR](https://en.wikipedia.org/wiki/Physically_based_rendering)
-material shading; simple fog; perspective and orthographic projections;
-texture-mapping - including with the output of other visual units (like a
-drawing canvas or a video)
-- simulating simple [physical particle systems](/docs/physics.md) (including
+- 3D rendering, including:
+  - primitive box, sphere, cylinder and cone shapes
+  - external triangular mesh models in a variety of formats including OBJ
+    and STL
+  - texture mapping, including with the output of other visual units (e.g., a
+    drawing canvas or a video)
+  - planar slicing and union, difference and intersection of solid models
+  - ambient, directional, point and spotlight sources (currently shadowless)
+  - [PBR](https://en.wikipedia.org/wiki/Physically_based_rendering) material
+    shading, emissive objects and transparency
+  - multiple cameras with individual control over location, field-of-view, near
+    and far clip planes, render buffer size, color depth, MSAA samples,
+    perspective/orthographic projection, fog, conversion to monochrome and
+    colour tinting
+- simulating simple [physical particle systems](/docs/physics.md), including
 spring/rod/rubber-band constraints, gravity, electrostatic charge, inertia,
-drag, barriers and particle collisions)
-- playing videos at arbitrary speeds (including in reverse, although video will
+drag, barriers and particle collisions
+- playing videos at arbitrary speeds, including in reverse (although video will
 stutter if it makes extensive use of P-frames)
-- running GLSL shaders as stacked image generators and filters, with live
-manipulation of uniforms and live reload of source
+- running GLSL shaders as stacked image filters and generators, with per-frame
+control of arbitrary uniforms
 - compositing all of the above and rendering to one or more windows
-- saving rendering output to image and video files (including the lockstep
-frame-by-frame video output suitable for producing perfect loops)
+- saving rendered output to image and video files (including lockstep
+frame-by-frame video output suitable for producing perfect loops and direct
+generation of animated GIFs)
 - driving arbitrary DMX fixtures via a USB DMX interface (currently via an
 Entec-compatible interface or my own crazy hand-built devices)
 - driving a LaserCube plugged in over USB (other lasers probably easy-ish to

--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ The first-level runtime dependencies are:
 - `loguru` - for enhanced logging
 - `mako` - for templating of the GLSL source
 - `manifold3d` - used by `trimesh` for 3D mesh boolean operations
+- `mapbox_earcut` - used by `trimesh` for triangulating polygons
 - `moderngl` - for a higher-level API to OpenGL
 - `networkx` - used by `trimesh` for some 3D mesh operations
 - `numpy` - for fast memory crunching
@@ -111,6 +112,7 @@ The first-level runtime dependencies are:
 - `regex` - used by `lark` for advanced regular expressions
 - `rtmidi2` - for talking MIDI to control surfaces
 - `scipy` - used by `trimesh` for some 3D mesh operations
+- `shapely` - used by `trimesh` for 2D shape analysis
 - `skia-python` - for 2D drawing
 - `trimesh` - for loading 3D meshes
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ The first-level runtime dependencies are:
 - `lark` - for the language parser
 - `loguru` - for enhanced logging
 - `mako` - for templating of the GLSL source
-- `manifold3d` - for sold-model boolean operations
+- `manifold3d` - for 3D mesh boolean operations
 - `moderngl` - for a higher-level API to OpenGL
 - `numpy` - for fast memory crunching
 - `pillow` - for saving screenshots as image files
@@ -109,7 +109,7 @@ The first-level runtime dependencies are:
 - `pyusb` - for low-level communication with the Push 2 and LaserCube
 - `regex` - used by `lark` for advanced regular expressions
 - `rtmidi2` - for talking MIDI to control surfaces
-- `scipy` - for computing convex hulls
+- `scipy` - for some 3D mesh operations
 - `skia-python` - for 2D drawing
 - `trimesh` - for loading 3D meshes
 

--- a/README.md
+++ b/README.md
@@ -110,18 +110,19 @@ The first-level runtime dependencies are:
 - `lark` - for the language parser
 - `loguru` - for enhanced logging
 - `mako` - for templating of the GLSL source
-- `manifold3d` - used by `trimesh` for 3D mesh boolean operations
+- `manifold3d` - used by `trimesh` for 3D boolean operations
 - `mapbox_earcut` - used by `trimesh` for triangulating polygons
 - `moderngl` - for a higher-level API to OpenGL
-- `networkx` - used by `trimesh` for some 3D mesh operations
+- `networkx` - used by `trimesh` for graph algorithms
 - `numpy` - for fast memory crunching
 - `pillow` - for saving screenshots as image files
 - `pyserial` - for talking to DMX interfaces
 - `pyusb` - for low-level communication with the Push 2 and LaserCube
 - `regex` - used by `lark` for advanced regular expressions
 - `rtmidi2` - for talking MIDI to control surfaces
-- `scipy` - used by `trimesh` for some 3D mesh operations
-- `shapely` - used by `trimesh` for 2D shape analysis
+- `rtree` - used by `trimesh` for spatial tree intersection
+- `scipy` - used by `trimesh` for computing convex hulls
+- `shapely` - used by `trimesh` for polygon operations
 - `skia-python` - for 2D drawing
 - `trimesh` - for loading 3D meshes
 

--- a/README.md
+++ b/README.md
@@ -101,6 +101,7 @@ The first-level runtime dependencies are:
 - `lark` - for the language parser
 - `loguru` - for enhanced logging
 - `mako` - for templating of the GLSL source
+- `manifold3d` - for sold-model boolean operations
 - `moderngl` - for a higher-level API to OpenGL
 - `numpy` - for fast memory crunching
 - `pillow` - for saving screenshots as image files
@@ -108,6 +109,7 @@ The first-level runtime dependencies are:
 - `pyusb` - for low-level communication with the Push 2 and LaserCube
 - `regex` - used by `lark` for advanced regular expressions
 - `rtmidi2` - for talking MIDI to control surfaces
+- `scipy` - for computing convex hulls
 - `skia-python` - for 2D drawing
 - `trimesh` - for loading 3D meshes
 

--- a/examples/solidgeometry.fl
+++ b/examples/solidgeometry.fl
@@ -1,21 +1,40 @@
+-- This example will be initially very jittery as it caches the generated
+-- models. Note the use of the `stepped()` function to limit the number of
+-- cached models to a number that keeps the animation reasonably smooth while
+-- avoiding doing too much model generation.
 
 %pragma tempo 60
 
-func stepped(x, n=256)
+func stepped(x, n=100)
     x*n // 1 / n
 
 !window size=1080
     !canvas3d samples=4 viewpoint=0;0;20 near=1 far=50
         !light color=0.1
-        !light color=0.9 direction=1;-1;-1
+        !light color=0.9 direction=1;0;-1
         !transform rotate=beat/30;beat/20;beat/30
             let n=12
             for i in ..n
-                let r=stepped(2+0.75*sine(beat/10+i/n))
+                let r=2.05+0.7*stepped(sine(beat/10+i/n))
                 !material color=hsv(i/n+beat/30;1;1)
                     !transform rotate_y=i/n translate=0;0;10
-                        (!intersect) if i % 2 == 0 else (!difference)
-                            !box size=4
-                            !sphere size=r
-            !slice position=1;0;0 normal=1;1;0 color=0.5
-                !box size=6;4;4
+                        if i % 2 == 0
+                            !intersect
+                                !box size=4
+                                !sphere size=r
+                        else
+                            !difference
+                                !box size=4
+                                !sphere size=r
+            !union color=0.5 roughness=0.3
+                !slice origin=0;1;0 normal=0.75;1;0
+                    !difference
+                        !box size=4;2;4
+                        !transform translate=0;-0.25;0
+                            !slice origin=0;1;0 normal=0.75;1;0
+                                !box size=3.5;2;3.5
+                    !difference
+                        !cylinder size=0.75;0.75;2 rotation=0.25;0;0
+                        !cylinder size=0.5;0.5;2 rotation=0.25;0;0
+                for i in (-1;1)
+                    !cylinder size=0.75 position=-1;1.125;i rotation=0.25;0;0

--- a/examples/solidgeometry.fl
+++ b/examples/solidgeometry.fl
@@ -14,9 +14,8 @@ func stepped(x, n=256)
                 let r=stepped(2+0.75*sine(beat/10+i/n))
                 !material color=hsv(i/n+beat/30;1;1)
                     !transform rotate_y=i/n translate=0;0;10
-                        ((!intersect) if i % 2 == 0 else (!difference)) smooth=0.1
+                        (!intersect) if i % 2 == 0 else (!difference)
                             !box size=4
-                            !sphere segments=64 size=r
-
-            !slice position=0;0;1 normal=1;0;1 smooth=0.1 color=0.5
+                            !sphere size=r
+            !slice position=1;0;0 normal=1;1;0 color=0.5
                 !box size=6;4;4

--- a/examples/solidgeometry.fl
+++ b/examples/solidgeometry.fl
@@ -14,6 +14,9 @@ func stepped(x, n=256)
                 let r=stepped(2+0.75*sine(beat/10+i/n))
                 !material color=hsv(i/n+beat/30;1;1)
                     !transform rotate_y=i/n translate=0;0;10
-                        (!intersect) if i % 2 == 0 else (!difference)
+                        ((!intersect) if i % 2 == 0 else (!difference)) smooth=0.1
                             !box size=4
                             !sphere segments=64 size=r
+
+            !slice position=0;0;1 normal=1;0;1 smooth=0.1 color=0.5
+                !box size=6;4;4

--- a/examples/solidgeometry.fl
+++ b/examples/solidgeometry.fl
@@ -1,0 +1,19 @@
+
+%pragma tempo 60
+
+func stepped(x, n=256)
+    x*n // 1 / n
+
+!window size=1080
+    !canvas3d samples=4 viewpoint=0;0;20 near=1 far=50
+        !light color=0.1
+        !light color=0.9 direction=1;-1;-1
+        !transform rotate=beat/30;beat/20;beat/30
+            let n=12
+            for i in ..n
+                let r=stepped(2+0.75*sine(beat/10+i/n))
+                !material color=hsv(i/n+beat/30;1;1)
+                    !transform rotate_y=i/n translate=0;0;10
+                        (!intersect) if i % 2 == 0 else (!difference)
+                            !box size=4
+                            !sphere segments=64 size=r

--- a/examples/textures.fl
+++ b/examples/textures.fl
@@ -18,7 +18,7 @@
 
 import bloom_filter from 'bloom.fl'
 
-let SIZE=(1920;1080)*2
+let SIZE=1920;1080
     days=beat/60
 
 !window size=SIZE

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,6 +25,7 @@ install_requires =
     pyusb
     regex
     rtmidi2
+    rtree
     scipy
     shapely
     skia-python

--- a/setup.cfg
+++ b/setup.cfg
@@ -15,6 +15,7 @@ install_requires =
     lark
     loguru
     mako
+    manifold3d
     moderngl
     numpy
     pillow
@@ -22,6 +23,7 @@ install_requires =
     pyusb
     regex
     rtmidi2
+    scipy
     skia-python
     trimesh
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,6 +17,7 @@ install_requires =
     mako
     manifold3d
     moderngl
+    networkx
     numpy
     pillow
     pyserial

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ install_requires =
     loguru
     mako
     manifold3d
+    mapbox_earcut
     moderngl
     networkx
     numpy
@@ -25,6 +26,7 @@ install_requires =
     regex
     rtmidi2
     scipy
+    shapely
     skia-python
     trimesh
 

--- a/src/flitter/render/window/canvas3d.pyx
+++ b/src/flitter/render/window/canvas3d.pyx
@@ -395,7 +395,7 @@ cdef Model get_model(Node node, bint top):
                 model = model.smooth_shade(smooth, minimum_area)
             if node.get_bool('invert', False):
                 model = model.invert()
-        elif(transform_matrix := get_model_transform(node, IdentityTransform)) is not IdentityTransform:
+        elif (transform_matrix := get_model_transform(node, IdentityTransform)) is not IdentityTransform:
             model = model.transform(transform_matrix)
     return model
 

--- a/src/flitter/render/window/canvas3d.pyx
+++ b/src/flitter/render/window/canvas3d.pyx
@@ -322,30 +322,51 @@ cdef Model get_model(Node node, bint top):
     cdef Node child
     cdef Model model = None
     cdef Model child_model = None
+    cdef list models
     if node.kind == 'intersect':
+        models = []
         child = node.first_child
         while child is not None:
             child_model = get_model(child, False)
-            model = child_model if model is None else model.intersect(node, child_model)
+            models.append(child_model)
             child = child.next_sibling
+        if len(models) == 1:
+            model = models[0]
+        else:
+            model = Model.intersect(node, models)
     elif node.kind == 'union':
+        models = []
         child = node.first_child
         while child is not None:
             child_model = get_model(child, False)
-            model = child_model if model is None else model.union(node, child_model)
+            models.append(child_model)
             child = child.next_sibling
+        if len(models) == 1:
+            model = models[0]
+        else:
+            model = Model.union(node, models)
     elif node.kind == 'difference':
+        models = []
         child = node.first_child
         while child is not None:
             child_model = get_model(child, False)
-            model = child_model if model is None else model.difference(node, child_model)
+            models.append(child_model)
             child = child.next_sibling
+        if len(models) == 1:
+            model = models[0]
+        else:
+            model = Model.difference(node, models)
     elif node.kind == 'transform':
+        models = []
         child = node.first_child
         while child is not None:
             child_model = get_model(child, False)
-            model = child_model if model is None else model.union(node, child_model)
+            models.append(child_model)
             child = child.next_sibling
+        if len(models) == 1:
+            model = models[0]
+        else:
+            model = Model.union(node, models)
         if model is not None and (transform_matrix := update_transform_matrix(node, IdentityTransform)) is not IdentityTransform:
             model = model.transform(transform_matrix)
     else:

--- a/src/flitter/render/window/canvas3d.pyx
+++ b/src/flitter/render/window/canvas3d.pyx
@@ -330,7 +330,8 @@ cdef Model get_model(Node node, bint top):
         child = node.first_child
         while child is not None:
             child_model = get_model(child, False)
-            models.append(child_model)
+            if child_model is not None:
+                models.append(child_model)
             child = child.next_sibling
         if models:
             model = models[0] if len(models) == 1 else Model.intersect(models)
@@ -339,7 +340,8 @@ cdef Model get_model(Node node, bint top):
         child = node.first_child
         while child is not None:
             child_model = get_model(child, False)
-            models.append(child_model)
+            if child_model is not None:
+                models.append(child_model)
             child = child.next_sibling
         if models:
             model = models[0] if len(models) == 1 else Model.union(models)
@@ -348,7 +350,8 @@ cdef Model get_model(Node node, bint top):
         child = node.first_child
         while child is not None:
             child_model = get_model(child, False)
-            models.append(child_model)
+            if child_model is not None:
+                models.append(child_model)
             child = child.next_sibling
         if models:
             model = models[0] if len(models) == 1 else Model.difference(models)
@@ -357,24 +360,25 @@ cdef Model get_model(Node node, bint top):
         child = node.first_child
         while child is not None:
             child_model = get_model(child, False)
-            models.append(child_model)
+            if child_model is not None:
+                models.append(child_model)
             child = child.next_sibling
         if models:
             model = models[0] if len(models) == 1 else Model.union(models)
             if model is not None and (transform_matrix := update_transform_matrix(node, IdentityTransform)) is not IdentityTransform:
                 model = model.transform(transform_matrix)
     elif node.kind == 'slice':
+        normal = node.get_fvec('normal', 3, None)
+        origin = node.get_fvec('origin', 3, Zero3)
         models = []
         child = node.first_child
         while child is not None:
             child_model = get_model(child, False)
-            models.append(child_model)
+            if child_model is not None:
+                models.append(child_model.slice(origin, normal) if normal is not None else child_model)
             child = child.next_sibling
         if models:
             model = models[0] if len(models) == 1 else Model.union(models)
-            if model is not None and (normal := node.get_fvec('normal', 3, None)) is not None:
-                origin = node.get_fvec('origin', 3, Zero3)
-                model = model.slice(origin, normal.normalize())
     else:
         if node.kind == 'box':
             model = Model.get_box(node)

--- a/src/flitter/render/window/canvas3d.pyx
+++ b/src/flitter/render/window/canvas3d.pyx
@@ -18,7 +18,7 @@ from ... import name_patch
 from ...clock import system_clock
 from ...model cimport Node, Vector, Matrix44, Matrix33, null_, true_
 from .glsl import TemplateLoader
-from .models cimport Model
+from .models cimport Model, DefaultSmooth
 
 
 logger = name_patch(logger, __name__)
@@ -392,8 +392,8 @@ cdef Model get_model(Node node, bint top):
             model = Model.get_external(node)
         if model is not None and not top and (transform_matrix := get_model_transform(node, IdentityTransform)) is not IdentityTransform:
             model = model.transform(transform_matrix)
-    if top and (smooth := node.get_float('smooth', 0)) > 0:
-        minimum_area = node.get_float('minimum_area', 0.01)
+    if top and (smooth := node.get_float('smooth', DefaultSmooth if model.is_constructed() else 0)) > 0:
+        minimum_area = max(0, node.get_float('minimum_area', 0))
         model = model.smooth_shade(smooth, minimum_area)
     return model
 

--- a/src/flitter/render/window/models.pxd
+++ b/src/flitter/render/window/models.pxd
@@ -1,49 +1,49 @@
 # cython: language_level=3, profile=True
 
-from ...model cimport Node
+from ...model cimport Node, Matrix44
 
 
 cdef class Model:
     cdef str name
-
-    cdef tuple get_buffers(self, object glctx, dict objects)
-
-
-cdef class TrimeshModel(Model):
     cdef bint flat
     cdef bint invert
     cdef object trimesh_model
 
     cdef object get_trimesh_model(self)
+    cdef tuple get_buffers(self, object glctx, dict objects)
+    cdef Model transform(self, Matrix44 transform_matrix)
+    cdef Model intersect(self, Model model)
+    cdef Model union(self, Model model)
+    cdef Model difference(self, Model model)
 
 
-cdef class Box(TrimeshModel):
+cdef class Box(Model):
     @staticmethod
     cdef Box get(Node node)
 
 
-cdef class Sphere(TrimeshModel):
+cdef class Sphere(Model):
     cdef int segments
 
     @staticmethod
     cdef Sphere get(Node node)
 
 
-cdef class Cylinder(TrimeshModel):
+cdef class Cylinder(Model):
     cdef int segments
 
     @staticmethod
     cdef Cylinder get(Node node)
 
 
-cdef class Cone(TrimeshModel):
+cdef class Cone(Model):
     cdef int segments
 
     @staticmethod
     cdef Cone get(Node node)
 
 
-cdef class ExternalModel(TrimeshModel):
+cdef class ExternalModel(Model):
     cdef str filename
 
     @staticmethod

--- a/src/flitter/render/window/models.pxd
+++ b/src/flitter/render/window/models.pxd
@@ -3,6 +3,9 @@
 from ...model cimport Node, Vector, Matrix44
 
 
+cdef double DefaultSmooth
+
+
 cdef class Model:
     cdef str name
     cdef bint flat
@@ -10,6 +13,7 @@ cdef class Model:
     cdef object trimesh_model
     cdef bint valid
 
+    cdef bint is_constructed(self)
     cdef bint check_valid(self)
     cdef void build_trimesh_model(self)
     cdef tuple get_buffers(self, object glctx, dict objects)

--- a/src/flitter/render/window/models.pxd
+++ b/src/flitter/render/window/models.pxd
@@ -15,10 +15,13 @@ cdef class Model:
     cdef tuple get_buffers(self, object glctx, dict objects)
 
     cdef Model transform(self, Matrix44 transform_matrix)
-    cdef Model intersect(self, Node node, Model model)
-    cdef Model union(self, Node node, Model model)
-    cdef Model difference(self, Node node, Model model)
 
+    @staticmethod
+    cdef Model intersect(Node node, list models)
+    @staticmethod
+    cdef Model union(Node node, list models)
+    @staticmethod
+    cdef Model difference(Node node, list models)
     @staticmethod
     cdef Model get_box(Node node)
     @staticmethod

--- a/src/flitter/render/window/models.pxd
+++ b/src/flitter/render/window/models.pxd
@@ -9,42 +9,23 @@ cdef class Model:
     cdef bint invert
     cdef object trimesh_model
 
-    cdef object get_trimesh_model(self)
+    cdef bint trimesh_model_unchanged(self)
+    cdef object build_trimesh_model(self)
+    cdef object get_render_trimesh_model(self)
     cdef tuple get_buffers(self, object glctx, dict objects)
+
     cdef Model transform(self, Matrix44 transform_matrix)
-    cdef Model intersect(self, Model model)
-    cdef Model union(self, Model model)
-    cdef Model difference(self, Model model)
-
-
-cdef class Box(Model):
-    @staticmethod
-    cdef Box get(Node node)
-
-
-cdef class Sphere(Model):
-    cdef int segments
+    cdef Model intersect(self, Node node, Model model)
+    cdef Model union(self, Node node, Model model)
+    cdef Model difference(self, Node node, Model model)
 
     @staticmethod
-    cdef Sphere get(Node node)
-
-
-cdef class Cylinder(Model):
-    cdef int segments
-
+    cdef Model get_box(Node node)
     @staticmethod
-    cdef Cylinder get(Node node)
-
-
-cdef class Cone(Model):
-    cdef int segments
-
+    cdef Model get_sphere(Node node)
     @staticmethod
-    cdef Cone get(Node node)
-
-
-cdef class ExternalModel(Model):
-    cdef str filename
-
+    cdef Model get_cylinder(Node node)
     @staticmethod
-    cdef ExternalModel get(Node node)
+    cdef Model get_cone(Node node)
+    @staticmethod
+    cdef Model get_external(Node node)

--- a/src/flitter/render/window/models.pxd
+++ b/src/flitter/render/window/models.pxd
@@ -8,9 +8,10 @@ cdef class Model:
     cdef bint flat
     cdef bint invert
     cdef object trimesh_model
+    cdef bint valid
 
-    cdef bint trimesh_model_unchanged(self)
-    cdef object build_trimesh_model(self)
+    cdef bint check_valid(self)
+    cdef void build_trimesh_model(self)
     cdef object get_render_trimesh_model(self)
     cdef tuple get_buffers(self, object glctx, dict objects)
 

--- a/src/flitter/render/window/models.pxd
+++ b/src/flitter/render/window/models.pxd
@@ -8,8 +8,6 @@ cdef double DefaultSmooth
 
 cdef class Model:
     cdef str name
-    cdef bint flat
-    cdef bint invert
     cdef object trimesh_model
     cdef bint valid
 
@@ -18,6 +16,8 @@ cdef class Model:
     cdef void build_trimesh_model(self)
     cdef tuple get_buffers(self, object glctx, dict objects)
 
+    cdef Model flatten(self)
+    cdef Model invert(self)
     cdef Model smooth_shade(self, double smooth, double minimum_area)
     cdef Model transform(self, Matrix44 transform_matrix)
     cdef Model slice(self, Vector position, Vector normal)

--- a/src/flitter/render/window/models.pxd
+++ b/src/flitter/render/window/models.pxd
@@ -1,6 +1,6 @@
 # cython: language_level=3, profile=True
 
-from ...model cimport Node, Matrix44
+from ...model cimport Node, Vector, Matrix44
 
 
 cdef class Model:
@@ -12,17 +12,19 @@ cdef class Model:
 
     cdef bint check_valid(self)
     cdef void build_trimesh_model(self)
-    cdef object get_render_trimesh_model(self)
     cdef tuple get_buffers(self, object glctx, dict objects)
 
+    cdef Model smooth_shade(self, double smooth, double minimum_area)
     cdef Model transform(self, Matrix44 transform_matrix)
+    cdef Model slice(self, Vector position, Vector normal)
 
     @staticmethod
-    cdef Model intersect(Node node, list models)
+    cdef Model intersect(list models)
     @staticmethod
-    cdef Model union(Node node, list models)
+    cdef Model union(list models)
     @staticmethod
-    cdef Model difference(Node node, list models)
+    cdef Model difference(list models)
+
     @staticmethod
     cdef Model get_box(Node node)
     @staticmethod

--- a/src/flitter/render/window/models.pyx
+++ b/src/flitter/render/window/models.pyx
@@ -353,7 +353,7 @@ cdef class Box(PrimitiveModel):
     @staticmethod
     cdef Box get(Node node):
         cdef bint invert = node.get_bool('invert', False)
-        cdef str name = 'box|invert' if invert else 'box'
+        cdef str name = '!box|invert' if invert else '!box'
         cdef Box model = ModelCache.pop(name, None)
         if model is None:
             model = Box.__new__(Box)

--- a/src/flitter/render/window/models.pyx
+++ b/src/flitter/render/window/models.pyx
@@ -243,7 +243,7 @@ cdef class SlicedModel(ModelTransformer):
             model.name = name
             model.original = original
             model.origin = origin
-            model.normal = normal
+            model.normal = normal.normalize()
         ModelCache[name] = model
         return model
 

--- a/src/flitter/render/window/models.pyx
+++ b/src/flitter/render/window/models.pyx
@@ -46,7 +46,6 @@ cdef class Model:
             if name in objects:
                 del objects[name]
             return None, None
-        logger.trace("Preparing model {}", name)
         while len(ModelCache) > MaxModelCacheEntries:
             dead_name = next(iter(ModelCache))
             del ModelCache[dead_name]
@@ -69,6 +68,7 @@ cdef class Model:
             vertex_data = np.hstack((trimesh_model.vertices, vertex_normals, vertex_uvs)).astype('f4')
             index_data = faces.astype('i4')
             buffers = (glctx.buffer(vertex_data), glctx.buffer(index_data))
+        logger.trace("Prepared model {} with {} vertices and {} faces", name, len(trimesh_model.vertices), len(trimesh_model.faces))
         objects[name] = buffers
         return buffers
 

--- a/src/flitter/render/window/models.pyx
+++ b/src/flitter/render/window/models.pyx
@@ -377,9 +377,8 @@ cdef class Sphere(PrimitiveModel):
     cdef Sphere get(Node node):
         cdef bint flat = node.get_bool('flat', False)
         cdef bint invert = node.get_bool('invert', False)
-        cdef int subdivisions = node.get_int('subdivisions', 3)
-        cdef int segments = max(4, node.get_int('segments', 4<<subdivisions))
-        cdef str name = f'!sphere-{segments}'
+        cdef int segments = max(4, node.get_int('segments', DefaultSegments))
+        cdef str name = f'!sphere-{segments}' if segments != DefaultSegments else '!sphere'
         if flat:
             name += '|flat'
         if invert:
@@ -449,7 +448,7 @@ cdef class Cylinder(PrimitiveModel):
         cdef bint flat = node.get_bool('flat', False)
         cdef bint invert = node.get_bool('invert', False)
         cdef int segments = max(2, node.get_int('segments', DefaultSegments))
-        cdef str name = f'!cylinder-{segments}'
+        cdef str name = f'!cylinder-{segments}' if segments != DefaultSegments else '!cylinder'
         if flat:
             name += '|flat'
         if invert:
@@ -540,7 +539,7 @@ cdef class Cone(PrimitiveModel):
         cdef bint flat = node.get_bool('flat', False)
         cdef bint invert = node.get_bool('invert', False)
         cdef int segments = max(2, node.get_int('segments', DefaultSegments))
-        cdef str name = f'!cone-{segments}'
+        cdef str name = f'!cone-{segments}' if segments != DefaultSegments else '!cone'
         if flat:
             name += '|flat'
         if invert:

--- a/tests/test_functions.py
+++ b/tests/test_functions.py
@@ -5,11 +5,6 @@ Tests of the flitter language built-in functions
 import math
 import unittest
 
-try:
-    from scipy.stats import kstest
-except ImportError:
-    kstest = None
-
 from flitter.model import Vector, Context, StateDict, null
 from flitter.language.functions import (Uniform, Normal, Beta, counter, hypot, angle, split, ordv, chrv)
 
@@ -75,8 +70,8 @@ class TestUniform(unittest.TestCase):
         self.assertIsNot(source1, source2)
         self.assertEqual(source1[:10_000], source2[:10_000])
 
-    @unittest.skipIf(kstest is None, "no scipy")
     def test_distribution(self):
+        from scipy.stats import kstest
         for i in range(2):
             with self.subTest(i=i):
                 result = kstest(self.FACTORY(i)[:10_000_000], *self.DISTRIBUTION)

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -5,11 +5,6 @@ Tests of the model.Vector class
 import math
 import unittest
 
-try:
-    from scipy.stats import kstest
-except ImportError:
-    kstest = None
-
 from flitter.model import Vector, true, false, null, Node
 
 
@@ -212,8 +207,8 @@ class TestVector(unittest.TestCase):
         self.assertIsNotNone(hash(Vector(test_func)))  # just check it works, value will not be stable
         self.assertIsNotNone(hash(Vector(test_class)))  # just check it works, value will not be stable
 
-    @unittest.skipIf(kstest is None, "no scipy")
     def test_hash_uniformity(self):
+        from scipy.stats import kstest
         hashes = []
         scale = 1 << 64
         for c0 in 'ABCDEFGHIJKLMNOPQRSTUVWXYZ':


### PR DESCRIPTION
This PR adds support for new `!slice`, `!intersect`, `!union` and `!difference` nodes in a `!canvas3d` scene that cut apart models and combine them with boolean operations. There are some important notes on this:

- models **must** be solid, steps will be taken to combine edges and fill holes; if necessary, the nuclear option is to compute a convex hull around the model
- because edges are combined, primitive models with sharp edges will lose their definition as their vertices are combined and vertex normals averaged – the operators will attempt to snap apart these edges again for rendering so as to retain smooth, natural shading (controlled by the `smooth=` and `minimum_area=` attributes
- solid model geometric operations are expensive, but they will be aggressively cached – if the operations have to be re-executed constantly because of dynamic parameters then it is a good idea to step these parameters so that caching will do something useful

This PR re-adds a hard requirement on **scipy** and introduces new ones on **manifold3d**, **mapbox_earcut**, **networkx**, **rtree** and **shapely**.