### PR TITLE
Convert language into a pure expression tree

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -739,6 +739,34 @@ that basis. Therefore, it is often more efficient to pass dynamic values (such
 as `beat`) into the function as parameters than allow them to be captured from
 the environment.
 
+## Anonymous functions
+
+**Flitter** also allows anonymous functions to be defined and used as values
+with the syntax:
+
+```flitter
+func (parameter《=default》《, parameter…》) body
+```
+
+In the grammar rules, anonymous functions sit above inline `if`/`else`
+expressions, but below inline `for` and `where` expressions. Therefore, the
+following creates a vector of 10 anonymous functions, each of which multiplies
+by a different value, not a single function that does 10 multiplications in
+a loop:
+
+```flitter
+let f = func(x) x*y for y in ..10
+```
+
+Note that as function calls are allowed to accept a vector of functions, it is
+valid to call `f`. So `f(3)` will still evaluate to `0;3;6;9;12;15;18;21;24;27`.
+
+It is wise to use parentheses to make the precedence explicit.
+
+As with regular functions, any captured names are bound at the point of
+definition. An anonymous function cannot be recursive as it has no function
+name to use within the body.
+
 ## Template function calls
 
 The special `@` operator provides syntactic sugar for calling a function using

--- a/docs/language.md
+++ b/docs/language.md
@@ -692,11 +692,11 @@ an insufficient number of matching arguments, otherwise any parameters lacking
 matching arguments will be bound to `null`. The result of evaluating all
 body expressions will be returned as a single vector to the caller.
 
-Functions may only be declared at the top-level of a program and so cannot be
-nested within another function definition. Functions may refer to names defined
-above the function definition at the top level. These will be captured at
-definition time. Thus rebinding a name later in the same scope will be ignored.
-For example:
+Functions may be declared anywhere in a program including within another
+function definition. Functions may refer to names defined outside of the
+function definition at the top level. The values of these names will be
+captured at definition time and so rebinding a name later in the same scope
+will be ignored. For example:
 
 ```flitter
 let x=10
@@ -732,7 +732,7 @@ the value `1` and `z` taking the value `3`. Named arguments should be given
 *after* any positional arguments and should not repeat positional arguments.
 
 Functions that have all literal (or unspecified) default parameter values, and
-that do not reference any non-local names within the body, will be in-lined by
+that do not reference any non-local names within the body, will be inlined by
 the simplifier at each call site. The simplifier is then able to bind the
 parameters to the argument expressions and continue simplifying the body on
 that basis. Therefore, it is often more efficient to pass dynamic values (such
@@ -813,8 +813,11 @@ between these different uses.
 
 ## Pragmas
 
-There are three supported pragmas that may be placed at the top-level of a
-source file:
+One or more pragmas may be placed at the top of a source file before any other
+expressions. Pragmas take a name and a value, which must be a literal number
+or string.
+
+There are three currently supported pragmas:
 
 ```flitter
 %pragma tempo 110
@@ -830,8 +833,8 @@ option).
 ## Imports
 
 Top-level definitions (`let`s and `func`s) may be imported from one **Flitter**
-program file into the top level of another. This allows common definitions to
-be collected into *modules* that can be used elsewhere. For example:
+program file into another. This allows common definitions to be collected into
+*modules* that can be used elsewhere. For example:
 
 ```flitter
 import SIZE;thing from 'common.fl'

--- a/src/flitter/engine/control.py
+++ b/src/flitter/engine/control.py
@@ -186,6 +186,7 @@ class EngineController:
                     level = 'SUCCESS' if current_program is None else 'INFO'
                     logger.log(level, "Loaded page {}: {}", self.current_page, self.current_path)
                     run_program = current_program = program
+                    self.handle_pragmas(program.pragmas, frame_time)
                     errors = set()
                     logs = set()
                     self.state_generation0 ^= self.state_generation1
@@ -243,7 +244,6 @@ class EngineController:
                     run_program.run(context, record_stats=self.vm_stats)
                 else:
                     context = Context()
-                self.handle_pragmas(context.pragmas, frame_time)
 
                 new_errors = context.errors.difference(errors) if errors is not None else context.errors
                 errors = context.errors

--- a/src/flitter/language/grammar.lark
+++ b/src/flitter/language/grammar.lark
@@ -69,6 +69,7 @@ compositions : comprehension (";" comprehension)+ -> tuple
 ?comprehension : conditional
                | comprehension "for" name_list "in" conditional -> inline_loop
                | comprehension "where" inline_bindings -> inline_let
+               | "func" _LPAREN parameters _RPAREN conditional -> anonymous_function
 
 inline_bindings: binding+ -> tuple
 

--- a/src/flitter/language/grammar.lark
+++ b/src/flitter/language/grammar.lark
@@ -2,7 +2,7 @@
 %import common.WS_INLINE
 %ignore WS_INLINE
 %ignore /\\$\n/m
-%declare _INDENT _DEDENT
+%declare _INDENT _DEDENT _EOF
 
 _NL: /((--[^\r\n]*)?\r?\n[\t ]*)+/
 
@@ -16,27 +16,26 @@ _HASHBANG : /#!.*\r?\n/
 _LPAREN : "("
 _RPAREN : ")"
 
-top : _HASHBANG? _NL? top_expressions
+top : _HASHBANG? _NL? pragmas _NL? sequence
 
-top_expressions : top_expression* -> tuple
+pragmas : pragma* -> tuple
 
-?top_expression : expression
-                | "let" multiline_bindings -> let
-                | "%pragma" NAME node _NL -> pragma
-                | "import" name_list "from" composition _NL ->  file_import
-                | "func" NAME _LPAREN parameters _RPAREN _NL _INDENT sequence _DEDENT -> function
+pragma : "%pragma" NAME literal _NL -> binding
 
-sequence : expressions [let_sequence]
+sequence : expressions
 
-let_sequence : "let" multiline_bindings sequence
+expressions : expression* let_expression? -> tuple
 
-expressions : expression* -> tuple
+let_expression : "let" multiline_bindings sequence -> let
+               | "func" NAME _LPAREN parameters _RPAREN _NL _INDENT sequence _DEDENT sequence -> function
+               | "import" name_list "from" composition _NL sequence ->  file_import
 
 ?expression : node _NL
             | node _NL _INDENT sequence _DEDENT -> append
             | "@" atom [attribute_bindings] _NL [_INDENT sequence _DEDENT] -> template_call
             | "for" name_list "in" range _NL _INDENT sequence _DEDENT -> loop
             | "if" tests ["else" _NL _INDENT sequence _DEDENT] -> if_else
+            | _EOF -> export
 
 parameters : (parameter ("," parameter)*)? -> tuple
 

--- a/src/flitter/language/grammar.lark
+++ b/src/flitter/language/grammar.lark
@@ -27,23 +27,25 @@ sequence : expressions
 expressions : expression* let_expression? -> tuple
 
 let_expression : "let" multiline_bindings sequence -> let
-               | "func" NAME _LPAREN parameters _RPAREN _NL _INDENT sequence _DEDENT sequence -> function
-               | "import" name_list "from" composition _NL sequence ->  file_import
+               | function sequence -> let_function
+               | "import" name_list "from" composition _NL sequence ->  let_import
 
 ?expression : node _NL
             | node _NL _INDENT sequence _DEDENT -> append
             | "@" atom [attribute_bindings] _NL [_INDENT sequence _DEDENT] -> template_call
             | "for" name_list "in" range _NL _INDENT sequence _DEDENT -> loop
-            | "if" tests ["else" _NL _INDENT sequence _DEDENT] -> if_else
+            | "if" conditions ["else" _NL _INDENT sequence _DEDENT] -> if_else
             | _EOF -> export
+
+function : "func" NAME _LPAREN parameters _RPAREN _NL _INDENT sequence _DEDENT
 
 parameters : (parameter ("," parameter)*)? -> tuple
 
 parameter : NAME ["=" node] -> binding
 
-tests : test ("elif" test)* -> tuple
+conditions : condition ("elif" condition)* -> tuple
 
-test : composition _NL _INDENT sequence _DEDENT
+condition : composition _NL _INDENT sequence _DEDENT
 
 ?node : composition
       | node TAG -> tag

--- a/src/flitter/language/parser.py
+++ b/src/flitter/language/parser.py
@@ -88,8 +88,8 @@ class FlitterTransformer(Transformer):
             return tree.Call(function, (sequence,), bindings)
         return tree.Call(function, (tree.Literal(model.null),), bindings or None)
 
-    def function(self, name, parameters, body, expression):
-        return tree.Let((tree.PolyBinding((name,), tree.Function(name, parameters, body)),), expression)
+    def let_function(self, function, sequence):
+        return tree.Let((tree.PolyBinding((function.name,), function),), sequence)
 
     tuple = v_args(inline=False)(tuple)
 
@@ -98,16 +98,18 @@ class FlitterTransformer(Transformer):
     attributes = tree.Attributes
     binding = tree.Binding
     bool = tree.Literal
+    condition = tree.IfCondition
     divide = tree.Divide
     export = tree.Export
     eq = tree.EqualTo
-    file_import = tree.Import
+    function = tree.Function
     floor_divide = tree.FloorDivide
     ge = tree.GreaterThanOrEqualTo
     gt = tree.GreaterThan
     if_else = tree.IfElse
     le = tree.LessThanOrEqualTo
     let = tree.Let
+    let_import = tree.Import
     literal = tree.Literal
     logical_and = tree.And
     logical_not = tree.Not
@@ -128,7 +130,6 @@ class FlitterTransformer(Transformer):
     slice = tree.Slice
     subtract = tree.Subtract
     tag = tree.Tag
-    test = tree.IfCondition
     top = tree.Top
 
 

--- a/src/flitter/language/parser.py
+++ b/src/flitter/language/parser.py
@@ -91,6 +91,9 @@ class FlitterTransformer(Transformer):
     def let_function(self, function, sequence):
         return tree.Let((tree.PolyBinding((function.name,), function),), sequence)
 
+    def anonymous_function(self, parameters, body):
+        return tree.Function('<anon>', parameters, body)
+
     tuple = v_args(inline=False)(tuple)
 
     add = tree.Add

--- a/src/flitter/language/vm.pxd
+++ b/src/flitter/language/vm.pxd
@@ -33,6 +33,7 @@ cdef class VectorStack:
 
 
 cdef class Program:
+    cdef readonly dict pragmas
     cdef readonly list instructions
     cdef bint linked
     cdef readonly object path
@@ -54,7 +55,6 @@ cdef class Program:
     cpdef Program jump(self, int64_t label)
     cpdef Program branch_true(self, int64_t label)
     cpdef Program branch_false(self, int64_t label)
-    cpdef Program pragma(self, str name)
     cpdef Program import_(self, tuple names)
     cpdef Program literal(self, value)
     cpdef Program local_push(self, int64_t count)
@@ -95,7 +95,7 @@ cdef class Program:
     cpdef Program begin_for(self, int64_t count)
     cpdef Program next(self, int64_t label)
     cpdef Program end_for(self)
-    cpdef Program store_global(self, str name)
+    cpdef Program export(self, str name)
     cpdef Program func(self, int64_t label, str name, tuple parameters, int64_t ncaptures=?)
     cpdef Program exit(self)
     cdef void _execute(self, Context context, int64_t pc, bint record_stats)

--- a/src/flitter/model.pxd
+++ b/src/flitter/model.pxd
@@ -167,12 +167,12 @@ cdef class StateDict:
 cdef class Context:
     cdef readonly dict names
     cdef readonly set captures
-    cdef readonly dict pragmas
     cdef readonly StateDict state
     cdef readonly Node root
     cdef readonly object path
     cdef readonly Context parent
     cdef readonly dict modules
+    cdef readonly dict exports
     cdef readonly set errors
     cdef readonly set logs
     cdef readonly dict references

--- a/src/flitter/model.pyx
+++ b/src/flitter/model.pyx
@@ -1941,16 +1941,16 @@ cdef class DummyStateDict(StateDict):
 
 
 cdef class Context:
-    def __init__(self, dict names=None, StateDict state=None, Node root=None, dict pragmas=None,
+    def __init__(self, dict names=None, StateDict state=None, Node root=None,
                  object path=None, Context parent=None, dict references=None, dict modules=None,
-                 set errors=None, set logs=None):
+                 dict exports=None, set errors=None, set logs=None):
         self.names = names if names is not None else {}
         self.state = state
         self.root = root if root is not None else Node('root')
-        self.pragmas = pragmas if pragmas is not None else {}
         self.path = path
         self.parent = parent
         self.modules = modules if modules is not None else {}
+        self.exports = exports if exports is not None else {}
         self.errors = errors if errors is not None else set()
         self.logs = logs if logs is not None else set()
         self.references = references

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -324,7 +324,7 @@ class TestImport(CompilerTestCase):
 
 class TestFunction(CompilerTestCase):
     def test_single_parameter_no_captures(self):
-        func = Function('func', (Binding('x', Literal(null)),), Add(Name('x'), Literal(5)))
+        func = Function('func', (Binding('x', Literal(null)),), Add(Name('x'), Literal(5)), captures=())
         program = Program()
         START = program.new_label()
         END = program.new_label()
@@ -339,8 +339,27 @@ class TestFunction(CompilerTestCase):
         program.func(START, 'func', ('x',), 0)
         self.assertCompilesTo(func, program)
 
+    def test_unknown_captures(self):
+        """If `captures` is `None` then *all* lnames are captured in case"""
+        func = Function('func', (Binding('x', Literal(null)),), Add(Name('x'), Literal(5)))
+        program = Program()
+        START = program.new_label()
+        END = program.new_label()
+        program.local_load(1)
+        program.local_load(0)
+        program.literal(null)
+        program.jump(END)
+        program.label(START)
+        program.local_load(0)
+        program.literal(5)
+        program.add()
+        program.exit()
+        program.label(END)
+        program.func(START, 'func', ('x',), 2)
+        self.assertCompilesTo(func, program, lnames=('a', 'b'))
+
     def test_two_parameters_no_captures(self):
-        func = Function('func', (Binding('x', Literal(null)), Binding('y', Literal(5))), Add(Name('x'), Name('y')))
+        func = Function('func', (Binding('x', Literal(null)), Binding('y', Literal(5))), Add(Name('x'), Name('y')), captures=())
         program = Program()
         START = program.new_label()
         END = program.new_label()
@@ -357,7 +376,7 @@ class TestFunction(CompilerTestCase):
         self.assertCompilesTo(func, program)
 
     def test_two_parameters_one_capture(self):
-        func = Function('func', (Binding('x', Literal(null)), Binding('y', Literal(5))), Multiply(Add(Name('x'), Name('y')), Name('z')))
+        func = Function('func', (Binding('x', Literal(null)), Binding('y', Literal(5))), Multiply(Add(Name('x'), Name('y')), Name('z')), captures=('z',))
         program = Program()
         START = program.new_label()
         END = program.new_label()
@@ -380,7 +399,8 @@ class TestFunction(CompilerTestCase):
         func = Function('func',
                         (Binding('x', Literal(null)),),
                         IfElse((IfCondition(GreaterThan(Name('x'), Literal(0)), Add(Name('x'), Call(Name('func'), (Subtract(Name('x'), Literal(1)),)))),),
-                               Literal(0)))
+                               Literal(0)),
+                        captures=())
         program = Program()
         START = program.new_label()
         END = program.new_label()

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -2,24 +2,56 @@
 Flitter language integration tests
 """
 
+import math
 from pathlib import Path
 import unittest
 
 from flitter import configure_logger
-from flitter.language.tree import Literal, Let, Sequence, Export
+from flitter.language.tree import Literal, Let, Sequence, Export, Binding, Top
 from flitter.language.parser import parse
-from flitter.model import Vector, Context, StateDict, DummyStateDict, null
+from flitter.language.vm import Function
+from flitter.model import Vector, Node, Context, StateDict, DummyStateDict, null
 
 
 configure_logger('WARNING')
 
 
+class TestPragmas(unittest.TestCase):
+    def test_no_pragmas(self):
+        top = parse("\n")
+        self.assertEqual(top.pragmas, ())
+        program = top.compile()
+        self.assertEqual(program.pragmas, {})
+
+    def test_pragmas(self):
+        top = parse("""
+%pragma foo 5
+%pragma bar 'five'
+%pragma baz :five
+%pragma buz !five
+""")
+        self.assertEqual(repr(top), repr(Top((Binding('foo', Literal(5)),
+                                              Binding('bar', Literal('five')),
+                                              Binding('baz', Literal(Vector.symbol('five'))),
+                                              Binding('buz', Literal(Node('five')))), Sequence((Export(None),)))))
+        program = top.compile()
+        self.assertEqual(program.pragmas, {'foo': Vector(5), 'bar': Vector('five'), 'baz': Vector.symbol('five'), 'buz': Vector(Node('five'))})
+
+
 class TestLanguageFeatures(unittest.TestCase):
+    """
+    Test a series of language features by parsing the given code, evaluating it and comparing the
+    output to that given. The code is evaluated in two ways:
+
+    1. Compile the unsimplified AST and run the resulting VM program with any additional bound
+       names passed in as initial lvalues
+    2. Simplify the AST with any additional bound names passed in as static, then extract the
+       literal values out of the resulting AST
+
+    It is assumed that all of the examples can be fully reduced to a literal by the simplifier.
+    """
+
     def assertCodeOutput(self, code, output, **names):
-        """
-        Tests that the supplied code produces the supplied output when compiled and
-        run dynamically in the VM, and also when statically evaluated by the simplifier.
-        """
         top = parse(code.strip() + "\n")
         output = output.strip()
         run_context = Context(names={name: Vector(value) for name, value in names.items()}, state=StateDict())
@@ -100,6 +132,37 @@ for i in ..n
  !item numbers=3;6;9
             """, n=4)
 
+    def test_if(self):
+        self.assertCodeOutput(
+            """
+for i in ..2
+    if i
+        !one
+            """,
+            """
+!one
+            """)
+
+    def test_if_else(self):
+        self.assertCodeOutput(
+            """
+for i in ..4
+    if not i
+        !zero
+    elif i == 2
+        !two
+    elif i > 2
+        !more
+    else
+        !one
+            """,
+            """
+!zero
+!one
+!two
+!more
+            """)
+
     def test_recursive_inlined_function(self):
         # Also default parameter values and out-of-order named arguments
         self.assertCodeOutput(
@@ -167,6 +230,37 @@ func fib(n)
 
 
 class TestExampleScripts(unittest.TestCase):
+    """
+    Run all Flitter scripts in `/examples`, `/docs/diagrams` and `/docs/tutorial_images` under three
+    different conditions and test that the generated root nodes and exported values match:
+
+    1. Compile the AST and run it without *any* simplification and with an empty state
+    2. Simplify the AST with known names (`beat`, etc.) as dynamic and an empty state
+    3. Simplify the AST with known names as static values and a special dummy state that claims to
+       contain all keys but returns null for all as an empty state would
+
+    In the third case, all state lookups will be statically evaluated to literal nulls by the
+    simplifier. The idea is to exercise the simplifier as much as possible.
+    """
+
+    def assertAllAlmostEqual(self, xs, ys, msg=None):
+        for x, y in zip(xs, ys):
+            self.assertEqual(math.isnan(x), math.isnan(y), msg=msg)
+            if not (math.isnan(x) or math.isnan(y)):
+                self.assertAlmostEqual(x, y, msg=msg)
+
+    def assertExportsMatch(self, exports1, exports2, msg=None):
+        self.assertEqual(exports1.keys(), exports2.keys())
+        for name in exports1:
+            a = exports1[name]
+            b = exports2[name]
+            if a.isinstance(Function) and b.isinstance(Function):
+                self.assertEqual(a[0].__name__, b[0].__name__, msg=msg)
+            elif a.numeric and b.numeric:
+                self.assertAllAlmostEqual(a, b, msg=msg)
+            else:
+                self.assertEqual(a, b, msg=msg)
+
     def _test_integration_script(self, filepath):
         self.maxDiff = None
         state = StateDict()
@@ -177,7 +271,9 @@ class TestExampleScripts(unittest.TestCase):
         program1 = top.compile(initial_lnames=tuple(names))
         program1.set_path(filepath)
         program1.use_simplifier(False)
-        root1 = program1.run(Context(names=dict(names), state=state)).root
+        context = program1.run(Context(names=dict(names), state=state))
+        root1 = context.root
+        exports1 = context.exports
         windows = [node for node in root1.children if node.kind == 'window']
         self.assertEqual(len(windows), 1, msg="Should be a single window node in program output")
         self.assertGreater(len(tuple(windows[0].children)), 0, "Output window node should have children")
@@ -187,16 +283,24 @@ class TestExampleScripts(unittest.TestCase):
         program2 = top2.compile(initial_lnames=tuple(names))
         program2.set_path(filepath)
         self.assertNotEqual(len(program1), len(program2), msg="Dynamically-simplified program length should be different from original")
-        root2 = program2.run(Context(names=dict(names), state=state)).root
+        context = program2.run(Context(names=dict(names), state=state))
+        root2 = context.root
+        exports2 = context.exports
         self.assertEqual(repr(root2), repr(root1), msg="Dynamically-simplified program output doesn't match original")
+        self.assertExportsMatch(exports2, exports1, msg="Dynamically-simplified program exports don't match original")
         # Simplify AST with static names and null state, compile and execute:
         top3 = top.simplify(static=names, state=null_state)
         self.assertEqual(repr(top3.simplify(static=names, state=null_state)), repr(top3), msg="Static simplification not complete in one step")
         program3 = top3.compile()
         program3.set_path(filepath)
         self.assertNotEqual(len(program3), len(program1), msg="Statically-simplified program length should be different from original")
-        root3 = program3.run(Context(state=state)).root
+        context = program3.run(Context(state=state))
+        root3 = context.root
+        exports3 = context.exports
+        for name in names:
+            del exports3[name]
         self.assertEqual(repr(root3), repr(root1), msg="Statically-simplified program output doesn't match original")
+        self.assertExportsMatch(exports3, exports1, msg="Statically-simplified program exports don't match original")
 
     def _test_integration_all_scripts(self, dirpath):
         count = 0

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -228,6 +228,21 @@ func fib(n)
 !fib x=55
             """)
 
+    def test_anonymous_functions(self):
+        """Note that this is only statically reducible because `map` is inlined and so the
+           anonymous function is bound to `f` and therefore becomes a name"""
+        self.assertCodeOutput(
+            """
+func map(f, xs)
+    for x in xs
+        f(x)
+
+!doubled x=map(func(x, y=2) x*y, ..10)
+            """,
+            """
+!doubled x=0;2;4;6;8;10;12;14;16;18
+            """)
+
 
 class TestExampleScripts(unittest.TestCase):
     """

--- a/tests/test_simplifier.py
+++ b/tests/test_simplifier.py
@@ -876,27 +876,29 @@ class TestCall(SimplifierTestCase):
 
     def test_simple_inlining(self):
         """Calls to names that resolve to Function objects are inlined as let expressions"""
-        func = Function('func', (Binding('x', Literal(null)),), Add(Name('x'), Literal(5))).simplify()
+        func = Function('func', (Binding('x', Literal(null)),), Add(Name('x'), Literal(5)), captures=(), inlineable=True)
         self.assertSimplifiesTo(Call(Name('func'), (Add(Literal(1), Name('y')),), ()),
                                 Let((PolyBinding(('x',), Add(Literal(1), Name('y'))),), Add(Name('x'), Literal(5))),
                                 static={'func': func}, dynamic={'y'})
 
-    def test_recursive_non_literal(self):
-        """Calls to names that resolve to recursive Function objects are not inlined if arguments are not all literal"""
+    def test_inlineable_recursive_non_literal(self):
+        """Calls to inlineable, recursive functions are *not* inlined if arguments are not all literal"""
         func = Function(
             'func',
             (Binding('x', Literal(null)),),
-            IfElse((IfCondition(GreaterThan(Name('x'), Literal(0)), Add(Name('x'), Call(Name('func'), (Subtract(Name('x'), Literal(1)),)))),), Literal(0))
-        ).simplify()
+            IfElse((IfCondition(GreaterThan(Name('x'), Literal(0)), Add(Name('x'), Call(Name('func'), (Subtract(Name('x'), Literal(1)),)))),), Literal(0)),
+            captures=(), inlineable=True, recursive=True
+        )
         self.assertSimplifiesTo(Call(Name('func'), (Name('y'),)), Call(Name('func'), (Name('y'),)), static={'func': func}, dynamic={'y'})
 
-    def test_recursive_literal_inlining(self):
-        """Calls to names that resolve to recursive Function objects are inlined if arguments are all literal"""
+    def test_inlineable_recursive_literal(self):
+        """Calls to inlineable, recursive functions *are* inlined if arguments are all literal"""
         func = Function(
             'func',
             (Binding('x', Literal(null)),),
-            IfElse((IfCondition(GreaterThan(Name('x'), Literal(0)), Add(Name('x'), Call(Name('func'), (Subtract(Name('x'), Literal(1)),)))),), Literal(0))
-        ).simplify()
+            IfElse((IfCondition(GreaterThan(Name('x'), Literal(0)), Add(Name('x'), Call(Name('func'), (Subtract(Name('x'), Literal(1)),)))),), Literal(0)),
+            captures=(), inlineable=True, recursive=True
+        )
         self.assertSimplifiesTo(Call(Name('func'), (Literal(5),)), Literal(15), static={'func': func})
 
 

--- a/tests/test_vm.py
+++ b/tests/test_vm.py
@@ -18,7 +18,8 @@ class TestBasicInstructions(unittest.TestCase):
         self.program = Program()
         self.state = StateDict()
         self.names = {}
-        self.context = Context(state=self.state, names=self.names)
+        self.exports = {}
+        self.context = Context(state=self.state, names=self.names, exports=self.exports)
 
     def test_Add(self):
         self.program.literal(3)
@@ -171,16 +172,16 @@ class TestBasicInstructions(unittest.TestCase):
         stack = self.program.execute(self.context)
         self.assertEqual(stack, [true, false])
 
-    def test_StoreGlobal(self):
+    def test_Export(self):
         self.program.literal((1, 2))
-        self.program.store_global('x')
+        self.program.export('x')
         self.program.literal(3)
-        self.program.store_global('y')
+        self.program.export('y')
         self.program.literal("Hello world!")
-        self.program.store_global('z')
+        self.program.export('z')
         stack = self.program.execute(self.context)
         self.assertEqual(len(stack), 0)
-        self.assertEqual(self.names, {'x': Vector([1, 2]), 'y': Vector(3), 'z': Vector("Hello world!")})
+        self.assertEqual(self.exports, {'x': Vector([1, 2]), 'y': Vector(3), 'z': Vector("Hello world!")})
 
     def test_Lookup(self):
         self.state['y'] = 12
@@ -260,13 +261,6 @@ class TestBasicInstructions(unittest.TestCase):
         self.program.pow()
         stack = self.program.execute(self.context)
         self.assertEqual(stack, [81])
-
-    def test_Pragma(self):
-        self.program.literal(3)
-        self.program.pragma('x')
-        stack = self.program.execute(self.context)
-        self.assertEqual(len(stack), 0)
-        self.assertEqual(self.context.pragmas, {'x': Vector(3)})
 
     def test_Range(self):
         self.program.literal(0)


### PR DESCRIPTION
Eliminate the special treatment of `Top` by making all let-likes "in"  expressions. Inject a new `Export` AST node at the end of the file – and  thus the deepest point in the tree. This exports all defined names to  allow importing to work. Language is now less rigid and allows functions  and imports to be anywhere. However, pragmas *must* now be at the top.  These are extracted by the parser instead of the runtime and so must be  simple literal AST nodes (a single number, string, etc.).