### PR TITLE
Vector *contains* operator

### DIFF
--- a/docs/language.md
+++ b/docs/language.md
@@ -1012,7 +1012,7 @@ code that will parse and run:
 let let=..10
 
 for in in let
-    !let in=in
+    !let let=in
 ```
 
 This is convenient in allowing things like `from` to be used as a keyword in an

--- a/docs/language.md
+++ b/docs/language.md
@@ -466,6 +466,14 @@ lesser. If an element pair cannot be compared because they are not of the same
 type, e.g., an attempt to compare a Unicode string with a number, then the
 result of the operator is the `null` vector.
 
+Additionally, a vector can be tested to see if it contains a sub-vector with
+the *contains* operator:
+
+- *x* `in` *y* - returns `true` if any sub-vector of `y` equals `x`
+
+This operator will always return `true` if *x* is the null vector, regardless
+of what *y* is.
+
 ### Logical operators
 
 Flitter also supports the usual short-cutting logical operators:

--- a/src/flitter/language/grammar.lark
+++ b/src/flitter/language/grammar.lark
@@ -99,6 +99,7 @@ name_list : NAME (";" NAME)* -> tuple
             | comparison ">" range -> gt
             | comparison "<=" range -> le
             | comparison ">=" range -> ge
+            | comparison "in" range -> contains
 
 ?range : sum
        | [sum] ".." sum ["|" sum] -> range

--- a/src/flitter/language/parser.py
+++ b/src/flitter/language/parser.py
@@ -109,6 +109,7 @@ class FlitterTransformer(Transformer):
     binding = tree.Binding
     bool = tree.Literal
     condition = tree.IfCondition
+    contains = tree.Contains
     divide = tree.Divide
     export = tree.Export
     eq = tree.EqualTo

--- a/src/flitter/language/tree.pyx
+++ b/src/flitter/language/tree.pyx
@@ -837,6 +837,18 @@ cdef class GreaterThanOrEqualTo(Comparison):
         program.ge()
 
 
+cdef class Contains(BinaryOperation):
+    cdef Vector op(self, Vector left, Vector right):
+        return right.contains(left)
+
+    cdef void _compile_op(self, Program program):
+        program.contains()
+
+    cdef Expression constant_left(self, Vector left, Expression right):
+        if left.length == 0:
+            return Literal(true_)
+
+
 cdef class And(BinaryOperation):
     cdef void _compile(self, Program program, list lnames):
         end_label = program.new_label()

--- a/src/flitter/language/vm.pxd
+++ b/src/flitter/language/vm.pxd
@@ -42,6 +42,7 @@ cdef enum OpCode:
     CallFast
     Ceil
     Compose
+    Contains
     Drop
     Dup
     EndFor
@@ -183,6 +184,7 @@ cdef class Program:
     cpdef Program floordiv(self)
     cpdef Program mod(self)
     cpdef Program pow(self)
+    cpdef Program contains(self)
     cpdef Program eq(self)
     cpdef Program ne(self)
     cpdef Program gt(self)

--- a/src/flitter/language/vm.pyx
+++ b/src/flitter/language/vm.pyx
@@ -69,6 +69,7 @@ cdef dict OpCodeNames = {
     OpCode.CallFast: 'CallFast',
     OpCode.Ceil: 'Ceil',
     OpCode.Compose: 'Compose',
+    OpCode.Contains: 'Contains',
     OpCode.Drop: 'Drop',
     OpCode.Dup: 'Dup',
     OpCode.EndFor: 'EndFor',
@@ -1002,6 +1003,10 @@ cdef class Program:
         self.instructions.append(Instruction(OpCode.Pow))
         return self
 
+    cpdef Program contains(self):
+        self.instructions.append(Instruction(OpCode.Contains))
+        return self
+
     cpdef Program eq(self):
         self.instructions.append(Instruction(OpCode.Eq))
         return self
@@ -1280,6 +1285,11 @@ cdef class Program:
                 elif instruction.code == OpCode.Pow:
                     r1 = pop(stack)
                     poke(stack, peek(stack).pow(r1))
+                    r1 = None
+
+                elif instruction.code == OpCode.Contains:
+                    r1 = pop(stack)
+                    poke(stack, r1.contains(peek(stack)))
                     r1 = None
 
                 elif instruction.code == OpCode.Eq:

--- a/src/flitter/model.pxd
+++ b/src/flitter/model.pxd
@@ -69,6 +69,7 @@ cdef class Vector:
     cdef Vector floor(self)
     cpdef Vector fract(self)
     cdef Vector round(self, int64_t ndigits)
+    cpdef Vector contains(self, Vector other)
     cdef Vector add(self, Vector other)
     cpdef Vector mul_add(self, Vector left, Vector right)
     cdef Vector sub(self, Vector other)

--- a/src/flitter/model.pyx
+++ b/src/flitter/model.pyx
@@ -744,6 +744,31 @@ cdef class Vector:
     def __round__(self, ndigits=None):
         return self.round(ndigits=ndigits if ndigits is not None else 0)
 
+    cpdef Vector contains(self, Vector other):
+        if other.length == 0:
+            return true_
+        if other.length > self.length:
+            return false_
+        cdef int64_t i, j
+        if other.objects is not None and self.objects is not None:
+            for i in range(self.length+1 - other.length):
+                for j in range(other.length):
+                    if other.objects[j] != self.objects[i+j]:
+                        break
+                else:
+                    return true_
+        elif other.numbers != NULL and self.numbers != NULL:
+            for i in range(self.length+1 - other.length):
+                for j in range(other.length):
+                    if other.numbers[j] != self.numbers[i+j]:
+                        break
+                else:
+                    return true_
+        return false_
+
+    def __contains__(self, other):
+        return self.contains(Vector._coerce(other)) is true_
+
     def __add__(self, other):
         return self.add(Vector._coerce(other))
 

--- a/src/flitter/model.pyx
+++ b/src/flitter/model.pyx
@@ -764,6 +764,13 @@ cdef class Vector:
                         break
                 else:
                     return true_
+        elif other.numbers != NULL and self.objects is not None:
+            for i in range(self.length+1 - other.length):
+                for j in range(other.length):
+                    if other.numbers[j] != self.objects[i+j]:
+                        break
+                else:
+                    return true_
         return false_
 
     def __contains__(self, other):

--- a/tests/test_compiler.py
+++ b/tests/test_compiler.py
@@ -10,7 +10,7 @@ from flitter.language import functions
 from flitter.language.tree import (Literal, Name, Sequence,
                                    Positive, Negative, Ceil, Floor, Fract, Power,
                                    Add, Subtract, Multiply, Divide, FloorDivide, Modulo,
-                                   EqualTo, NotEqualTo, LessThan, GreaterThan, LessThanOrEqualTo, GreaterThanOrEqualTo,
+                                   Contains, EqualTo, NotEqualTo, LessThan, GreaterThan, LessThanOrEqualTo, GreaterThanOrEqualTo,
                                    Not, And, Or, Xor, Range, Slice, Lookup,
                                    Tag, Attributes, Append,
                                    Let, Call, For, IfElse,
@@ -115,6 +115,9 @@ class TestBinaryExpressions(CompilerTestCase):
 
     def test_power(self):
         self.assertCompilesTo(Power(Name('x'), Name('y')), Program().local_load(1).local_load(0).pow(), lnames=('x', 'y'))
+
+    def test_contains(self):
+        self.assertCompilesTo(Contains(Name('x'), Name('y')), Program().local_load(1).local_load(0).contains(), lnames=('x', 'y'))
 
     def test_equal_to(self):
         self.assertCompilesTo(EqualTo(Name('x'), Name('y')), Program().local_load(1).local_load(0).eq(), lnames=('x', 'y'))

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -160,11 +160,11 @@ let y=1 y''=y+1 y'''=y''+1
     def test_contextual_parser(self):
         self.assertCodeOutput(
             """
-let let=import + 1
-!foo in=let
+let in=import + 1
+!foo let=in
             """,
             """
-!foo in=6
+!foo let=6
             """, **{'import': 5})
 
     def test_names(self):
@@ -362,6 +362,15 @@ func map(f, xs)
             """
 !foo
             """, with_errors={'Error calling hsv: hsv() takes exactly 1 positional argument (0 given)'})
+
+    def test_contains(self):
+        self.assertCodeOutput(
+            """
+!foo x=(x in y) y=(y in y) z=(y in x)
+            """,
+            """
+!foo x=1 y=1 z=0
+            """, x=Vector((4, 5, 6)), y=Vector.range(10))
 
 
 class ScriptTest(utils.TestCase):

--- a/tests/test_simplifier.py
+++ b/tests/test_simplifier.py
@@ -12,7 +12,7 @@ from flitter.language import functions
 from flitter.language.tree import (Literal, Name, Sequence,
                                    Positive, Negative, Ceil, Floor, Fract, Power,
                                    Add, Subtract, Multiply, Divide, FloorDivide, Modulo,
-                                   EqualTo, NotEqualTo, LessThan, GreaterThan, LessThanOrEqualTo, GreaterThanOrEqualTo,
+                                   Contains, EqualTo, NotEqualTo, LessThan, GreaterThan, LessThanOrEqualTo, GreaterThanOrEqualTo,
                                    Not, And, Or, Xor, Range, Slice, Lookup,
                                    Tag, Attributes, Append,
                                    Let, Call, For, IfElse,
@@ -493,6 +493,28 @@ class TestPower(SimplifierTestCase):
     def test_raise_to_power_of_one(self):
         """Power to literal 1 becomes Positive"""
         self.assertSimplifiesTo(Power(Name('x'), Literal(1)), Positive(Name('x')), dynamic={'x'})
+
+
+class TestContains(SimplifierTestCase):
+    def test_dynamic(self):
+        self.assertSimplifiesTo(Contains(Name('x'), Name('y')), Contains(Name('x'), Name('y')), dynamic={'x', 'y'})
+        self.assertSimplifiesTo(Contains(Literal(5), Name('y')), Contains(Literal(5), Name('y')), dynamic={'y'})
+        self.assertSimplifiesTo(Contains(Name('x'), Literal(5)), Contains(Name('x'), Literal(5)), dynamic={'x'})
+
+    def test_recursive(self):
+        """Left and right are simplified"""
+        self.assertSimplifiesTo(Contains(Name('x'), Name('y')), Contains(Name('x'), Name('z')), dynamic={'x', 'z'}, static={'y': Name('z')})
+        self.assertSimplifiesTo(Contains(Name('x'), Name('y')), Contains(Name('z'), Name('y')), dynamic={'y', 'z'}, static={'x': Name('z')})
+
+    def test_left_null(self):
+        """Literal null on left evaluates to true"""
+        self.assertSimplifiesTo(Contains(Literal(null), Name('y')), Literal(true), dynamic={'y'})
+
+    def test_literal(self):
+        """Literal left and right is evaluated"""
+        self.assertSimplifiesTo(Contains(Literal(5), Literal((4, 5, 6))), Literal(true))
+        self.assertSimplifiesTo(Contains(Literal((4, 5)), Literal((4, 5, 6))), Literal(true))
+        self.assertSimplifiesTo(Contains(Literal(5), Literal((7, 8, 9))), Literal(false))
 
 
 class TestEqualTo(SimplifierTestCase):

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -464,6 +464,31 @@ class TestVector(utils.TestCase):
         self.assertAllAlmostEqual(Vector(-3.5).fract(), Vector(0.5))
         self.assertAllAlmostEqual(Vector([0, 0.1, 3.5, -99.5, 1e-99, math.inf]).fract(), Vector([0, 0.1, 0.5, 0.5, 1e-99, math.nan]))
 
+    def test_round(self):
+        self.assertEqual(round(null), null)
+        self.assertEqual(round(Vector("Hello world!")), null)
+        self.assertAllAlmostEqual(round(Vector(-3.5)), Vector(-4))
+        self.assertAllAlmostEqual(round(Vector([0, 0.1, 3.4, -99.5, 1e-99, math.inf])), Vector([0, 0, 3, -100, 0, math.inf]))
+
+    def test_contains(self):
+        self.assertTrue(null in null)
+        self.assertFalse(Vector(4) in null)
+        self.assertTrue(null in Vector(4))
+        self.assertTrue(null in Vector('hello'))
+        self.assertFalse(-1 in Vector.range(10))
+        self.assertTrue(0 in Vector.range(10))
+        self.assertTrue(9 in Vector.range(10))
+        self.assertFalse(10 in Vector.range(10))
+        self.assertTrue(Vector([0, 1, 2]) in Vector.range(10))
+        self.assertFalse(Vector([0, 1, 3]) in Vector.range(10))
+        self.assertTrue(Vector([7, 8, 9]) in Vector.range(10))
+        self.assertFalse(Vector([8, 9, 10]) in Vector.range(10))
+        self.assertTrue(Vector.range(10) in Vector.range(10))
+        self.assertTrue(Vector("Hello") in Vector(["Hello", "world"]))
+        self.assertTrue(Vector(["world"]) in Vector(["Hello", "world"]))
+        self.assertTrue(Vector(["Hello", "world"]) in Vector(["Hello", "world"]))
+        self.assertFalse(Vector(["Hello", "Dave"]) in Vector(["Hello", "world"]))
+
     def test_add(self):
         x = Vector([1, 0.1, -5, 1e6, math.inf])
         self.assertEqual(x + null, null)

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -488,6 +488,7 @@ class TestVector(utils.TestCase):
         self.assertTrue(Vector(["world"]) in Vector(["Hello", "world"]))
         self.assertTrue(Vector(["Hello", "world"]) in Vector(["Hello", "world"]))
         self.assertFalse(Vector(["Hello", "Dave"]) in Vector(["Hello", "world"]))
+        self.assertTrue(Vector([1, 2]) in Vector(["Hello", 1, 2, "world"]))
 
     def test_add(self):
         x = Vector([1, 0.1, -5, 1e6, math.inf])


### PR DESCRIPTION
This PR adds a new `in` binary operator for testing if one vector contains another.

Note that this changes the grammar rules such that `in` is not a valid name in more places.