### PR TITLE
Identify 3D models using an integer ID instead of a name

### DIFF
--- a/examples/sdf.fl
+++ b/examples/sdf.fl
@@ -1,4 +1,8 @@
 
+-- This is the same as the internal SDF function for !cone, but slower
+func cone(p)
+    max(hypot(p[..2])+p[2], abs(p[2]))-0.5
+
 !window size=1080
     !record filename=(OUTPUT if frame == run_time * fps - 1)
         !canvas3d samples=4
@@ -13,7 +17,7 @@
                                     !cone
                             for i in ..2
                                 !transform rotate_x=0.25+i/2 translate=0;0;0.7 scale=0.3;0.3;0.6
-                                    !cone
+                                    !sdf function=cone
                         !trim normal=0;1;0 origin=0;0.25;0 smooth=0.1
                             !difference chamfer=0.05
                                 !intersect fillet=0.1

--- a/src/flitter/language/vm.pxd
+++ b/src/flitter/language/vm.pxd
@@ -1,7 +1,7 @@
 
 from cpython cimport PyObject
 
-from libc.stdint cimport int64_t
+from libc.stdint cimport int64_t, uint64_t
 
 from ..model cimport Vector, Node, Context
 
@@ -29,6 +29,22 @@ cdef class VectorStack:
     cpdef Vector peek_at(self, int64_t offset)
     cpdef void poke(self, Vector vector)
     cpdef void poke_at(self, int64_t offset, Vector vector)
+
+
+cdef class Function:
+    cdef readonly str __name__
+    cdef readonly Vector vself
+    cdef readonly tuple parameters
+    cdef readonly tuple defaults
+    cdef readonly Program program
+    cdef readonly int64_t address
+    cdef readonly bint record_stats
+    cdef readonly tuple captures
+    cdef readonly int64_t call_depth
+    cdef readonly uint64_t _hash
+
+    cdef uint64_t hash(self)
+    cdef Vector call_one_fast(self, Context context, Vector arg)
 
 
 cdef enum OpCode:

--- a/src/flitter/model.pxd
+++ b/src/flitter/model.pxd
@@ -32,6 +32,11 @@ cdef inline uint64_t HASH_STRING(str value):
     return y
 
 
+cdef union double_long:
+    double f
+    uint64_t l
+
+
 cdef class Vector:
     cdef int64_t length
     cdef tuple objects

--- a/src/flitter/model.pxd
+++ b/src/flitter/model.pxd
@@ -21,7 +21,7 @@ cdef inline uint64_t HASH_UPDATE(uint64_t _hash, uint64_t y) noexcept:
 
 
 # FNV-1a hash algorithm [https://en.wikipedia.org/wiki/Fowler–Noll–Vo_hash_function#FNV-1a_hash]
-cdef inline uint64_t HASH_STRING(str value):
+cdef inline uint64_t HASH_STRING(str value) noexcept:
     cdef void* data = PyUnicode_DATA(value)
     cdef uint64_t i, n=PyUnicode_GET_LENGTH(value), kind=PyUnicode_KIND(value)
     cdef Py_UCS4 c

--- a/src/flitter/model.pyx
+++ b/src/flitter/model.pyx
@@ -30,11 +30,6 @@ cdef dict SymbolTable = {}
 cdef dict ReverseSymbolTable = {}
 
 
-cdef union double_long:
-    double f
-    uint64_t l
-
-
 cdef inline int64_t vector_compare(Vector left, Vector right) noexcept:
     if left is right:
         return 0

--- a/src/flitter/render/window/canvas3d.pyx
+++ b/src/flitter/render/window/canvas3d.pyx
@@ -23,6 +23,7 @@ from ...model cimport Node, Vector, Matrix44, Matrix33, Quaternion, null_, true_
 from .models cimport Model, DefaultSegments, DefaultSnapAngle
 from .target import RenderTarget, COLOR_FORMATS
 from ...plugins import get_plugin
+from ...language.vm import Function
 
 
 logger = name_patch(logger, __name__)
@@ -493,7 +494,7 @@ cdef Model get_model(Node node, bint top):
         minimum = node.get_fvec('minimum', 3, node.get_fvec('min', 3, maximum.neg()))
         resolution = node.get_float('resolution', (maximum.maximum() - minimum.minimum()) / 100)
         if 'function' in node and (function := node['function']) and function.length == 1 and \
-                function.objects is not None and callable(f := function.objects[0]):
+                function.objects is not None and isinstance(f := function.objects[0], Function):
             model = Model._sdf(f, None, minimum, maximum, resolution)
         else:
             model = Model._boolean('union', [get_model(child, False) for child in node._children],

--- a/src/flitter/render/window/models.pxd
+++ b/src/flitter/render/window/models.pxd
@@ -1,7 +1,7 @@
 
 from ...model cimport Node, Vector, Matrix44
 
-from libc.stdint cimport int64_t
+from libc.stdint cimport int64_t, uint64_t
 
 
 cdef double DefaultSnapAngle
@@ -9,7 +9,7 @@ cdef int64_t DefaultSegments
 
 
 cdef class Model:
-    cdef readonly str name
+    cdef readonly uint64_t id
     cdef readonly double touch_timestamp
     cdef readonly double cache_timestamp
     cdef readonly dict cache

--- a/src/flitter/render/window/models.pxd
+++ b/src/flitter/render/window/models.pxd
@@ -1,5 +1,6 @@
 
 from ...model cimport Node, Vector, Matrix44
+from ...language.vm cimport Function
 
 from libc.stdint cimport int64_t, uint64_t
 
@@ -61,7 +62,7 @@ cdef class Model:
     cdef Model _vector(Vector vertices, Vector faces)
 
     @staticmethod
-    cdef Model _sdf(function, Model original, Vector minimum, Vector maximum, double resolution)
+    cdef Model _sdf(Function function, Model original, Vector minimum, Vector maximum, double resolution)
 
     @staticmethod
     cdef Model _mix(list models, Vector weights)

--- a/src/flitter/render/window/models.pyx
+++ b/src/flitter/render/window/models.pyx
@@ -48,13 +48,16 @@ cdef uint64_t MIX = HASH_UPDATE(HASH_START, HASH_STRING('mix'))
 cdef class Model:
     @staticmethod
     def flush_caches(double min_age=300, int64_t min_size=2000):
-        cdef double cutoff = perf_counter() - min_age
+        cdef double now = perf_counter()
+        cdef double cutoff = now - min_age
         cdef Model model
-        cdef int64_t unload_count=0, dump_count=0
-        cdef list unloaded=[]
+        cdef int64_t unload_count = 0
+        cdef list unloaded = []
         while len(ModelCache) > min_size:
             for model in ModelCache.values():
-                if model.touch_timestamp < cutoff and not model.dependents:
+                if model.touch_timestamp == 0:
+                    model.touch_timestamp = now
+                if model.touch_timestamp <= cutoff and not model.dependents:
                     unloaded.append(model)
             if not unloaded:
                 break
@@ -63,12 +66,6 @@ cdef class Model:
                 del ModelCache[model.id]
                 model.unload()
                 unload_count += 1
-        for model in ModelCache.values():
-            if model.cache_timestamp < cutoff and model.cache is not None:
-                model.cache = None
-                dump_count += 1
-        if dump_count:
-            logger.trace("Dumped sub-caches on {} models", dump_count)
         if unload_count:
             logger.trace("Unloaded {} models from cache, {} remaining", unload_count, len(ModelCache))
 
@@ -399,7 +396,7 @@ cdef class Flatten(UnaryOperation):
             ModelCache[id] = model
         else:
             model = <Flatten>objptr
-        model.touch_timestamp = perf_counter()
+            model.touch_timestamp = 0
         return model
 
     @property
@@ -440,7 +437,7 @@ cdef class Invert(UnaryOperation):
             ModelCache[id] = model
         else:
             model = <Invert>objptr
-        model.touch_timestamp = perf_counter()
+            model.touch_timestamp = 0
         return model
 
     @property
@@ -490,7 +487,7 @@ cdef class Repair(UnaryOperation):
             ModelCache[id] = model
         else:
             model = <Repair>objptr
-        model.touch_timestamp = perf_counter()
+            model.touch_timestamp = 0
         return model
 
     @property
@@ -537,7 +534,7 @@ cdef class SnapEdges(UnaryOperation):
             ModelCache[id] = model
         else:
             model = <SnapEdges>objptr
-        model.touch_timestamp = perf_counter()
+            model.touch_timestamp = 0
         return model
 
     @property
@@ -598,7 +595,7 @@ cdef class Transform(UnaryOperation):
             ModelCache[id] = model
         else:
             model = <Transform>objptr
-        model.touch_timestamp = perf_counter()
+            model.touch_timestamp = 0
         return model
 
     @property
@@ -667,7 +664,7 @@ cdef class UVRemap(UnaryOperation):
             ModelCache[id] = model
         else:
             model = <UVRemap>objptr
-        model.touch_timestamp = perf_counter()
+            model.touch_timestamp = 0
         return model
 
     @property
@@ -744,7 +741,7 @@ cdef class Trim(UnaryOperation):
             ModelCache[id] = model
         else:
             model = <Trim>objptr
-        model.touch_timestamp = perf_counter()
+            model.touch_timestamp = 0
         return model
 
     @property
@@ -866,7 +863,7 @@ cdef class BooleanOperation(Model):
             ModelCache[id] = model
         else:
             model = <BooleanOperation>objptr
-        model.touch_timestamp = perf_counter()
+            model.touch_timestamp = 0
         return model
 
     @property
@@ -1075,7 +1072,7 @@ cdef class Box(PrimitiveModel):
             ModelCache[id] = model
         else:
             model = <Box>objptr
-        model.touch_timestamp = perf_counter()
+            model.touch_timestamp = 0
         return model
 
     @property
@@ -1112,7 +1109,7 @@ cdef class Sphere(PrimitiveModel):
             ModelCache[id] = model
         else:
             model = <Sphere>objptr
-        model.touch_timestamp = perf_counter()
+            model.touch_timestamp = 0
         return model
 
     @property
@@ -1199,7 +1196,7 @@ cdef class Cylinder(PrimitiveModel):
             ModelCache[id] = model
         else:
             model = <Cylinder>objptr
-        model.touch_timestamp = perf_counter()
+            model.touch_timestamp = 0
         return model
 
     @property
@@ -1295,7 +1292,7 @@ cdef class Cone(PrimitiveModel):
             ModelCache[id] = model
         else:
             model = <Cone>objptr
-        model.touch_timestamp = perf_counter()
+            model.touch_timestamp = 0
         return model
 
     @property
@@ -1375,7 +1372,7 @@ cdef class ExternalModel(Model):
             ModelCache[id] = model
         else:
             model = <ExternalModel>objptr
-        model.touch_timestamp = perf_counter()
+            model.touch_timestamp = 0
         return model
 
     @property
@@ -1431,7 +1428,7 @@ cdef class VectorModel(Model):
             ModelCache[id] = model
         else:
             model = <VectorModel>objptr
-        model.touch_timestamp = perf_counter()
+            model.touch_timestamp = 0
         return model
 
     @property
@@ -1505,7 +1502,7 @@ cdef class SignedDistanceFunction(UnaryOperation):
                 original.add_dependent(model)
         else:
             model = <SignedDistanceFunction>objptr
-        model.touch_timestamp = perf_counter()
+            model.touch_timestamp = 0
         return model
 
     @property
@@ -1583,7 +1580,7 @@ cdef class Mix(Model):
             ModelCache[id] = model
         else:
             model = <Mix>objptr
-        model.touch_timestamp = perf_counter()
+            model.touch_timestamp = 0
         return model
 
     @property

--- a/src/flitter/render/window/models.pyx
+++ b/src/flitter/render/window/models.pyx
@@ -679,7 +679,6 @@ cdef class UVRemap(UnaryOperation):
 
     @cython.boundscheck(False)
     @cython.wraparound(False)
-    @cython.cdivision(True)
     cdef object remap_sphere(self, trimesh_model):
         cdef const float[:, :] vertices
         cdef object vertex_uv_array

--- a/src/flitter/render/window/models.pyx
+++ b/src/flitter/render/window/models.pyx
@@ -805,9 +805,9 @@ cdef class BooleanOperation(Model):
             child_model = models.pop()
             if child_model is None:
                 continue
-            if operation is 'union' \
-                    and isinstance(child_model, BooleanOperation) \
-                    and (<BooleanOperation>child_model).operation is 'union' \
+            if type(child_model) is BooleanOperation \
+                    and operation is not 'difference' \
+                    and (<BooleanOperation>child_model).operation is operation \
                     and (<BooleanOperation>child_model).smooth == smooth \
                     and (<BooleanOperation>child_model).fillet == fillet \
                     and (<BooleanOperation>child_model).chamfer == chamfer:

--- a/tests/test_language.py
+++ b/tests/test_language.py
@@ -519,6 +519,12 @@ class TestDocumentationDiagrams(ScriptTest):
     def test_pseudorandoms(self):
         self.assertSimplifierDoesntChangeBehaviour(self.DIAGRAMS / 'pseudorandoms.fl')
 
+    def test_spheroidbox(self):
+        self.assertSimplifierDoesntChangeBehaviour(self.DIAGRAMS / 'spheroidbox.fl')
+
+    def test_torus(self):
+        self.assertSimplifierDoesntChangeBehaviour(self.DIAGRAMS / 'torus.fl')
+
     def test_waveforms(self):
         self.assertSimplifierDoesntChangeBehaviour(self.DIAGRAMS / 'waveforms.fl')
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -31,6 +31,8 @@ class TestPrimitives(utils.TestCase):
         self.assertEqual(len(mesh.faces), 12)
         self.assertEqual(mesh.area, 6)
         self.assertEqual(mesh.volume, 1)
+        model = Model.box('repeat')
+        self.assertEqual(model.name, '!box-repeat')
 
     def test_sphere(self):
         for segments in (4, DefaultSegments, 1024):
@@ -49,6 +51,8 @@ class TestPrimitives(utils.TestCase):
                 else:
                     self.assertAlmostEqual(mesh.area, 4*math.pi, places=int(math.log10(segments)))
                     self.assertAlmostEqual(mesh.volume, 4/3*math.pi, places=int(math.log10(segments)))
+        self.assertEqual(Model.sphere(0).name, '!sphere-4')
+        self.assertEqual(Model.sphere(5).name, '!sphere-8')
 
     def test_cylinder(self):
         for segments in (4, DefaultSegments, 1024):
@@ -438,6 +442,7 @@ class TestStructuring(utils.TestCase):
         self.assertEqual(Model.intersect(Model.box(), Model.box()).name, '!box')
         self.assertEqual(Model.intersect(Model.box(), Model.sphere()).name, 'intersect(!box, !sphere)')
         self.assertEqual(Model.intersect(Model.box(), Model.sphere(), Model.box()).name, 'intersect(!box, !sphere)')
+        self.assertEqual(Model.intersect(Model.box(), Model.intersect(Model.sphere(), Model.cylinder())).name, 'intersect(!box, !sphere, !cylinder)')
         self.assertTrue(Model.intersect(Model.box(), Model.sphere()).is_smooth())
         self.assertEqual(Model.intersect(Model.box(), Model.sphere()).flatten().name, 'flatten(intersect(!box, !sphere))')
         self.assertEqual(Model.intersect(Model.box(), Model.sphere()).invert().name, 'invert(intersect(!box, !sphere))')
@@ -453,6 +458,8 @@ class TestStructuring(utils.TestCase):
         self.assertIsNone(Model.difference(Model.box(), Model.box()))
         self.assertEqual(Model.difference(Model.box(), Model.sphere()).name, 'difference(!box, !sphere)')
         self.assertIsNone(Model.difference(Model.box(), Model.sphere(), Model.box()))
+        self.assertEqual(Model.difference(Model.box(), Model.difference(Model.sphere(), Model.cylinder())).name,
+                         'difference(!box, difference(!sphere, !cylinder))')
         self.assertTrue(Model.difference(Model.box(), Model.sphere()).is_smooth())
         self.assertEqual(Model.difference(Model.box(), Model.sphere()).flatten().name, 'flatten(difference(!box, !sphere))')
         self.assertEqual(Model.difference(Model.box(), Model.sphere()).invert().name, 'invert(difference(!box, !sphere))')

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -478,7 +478,7 @@ class TestUVRemapping(utils.TestCase):
         model = Model.box()
         mesh = model.uv_remap('sphere').get_trimesh()
         for (x, y, z), uv in zip(mesh.vertices, mesh.visual.uv):
-            u = math.atan2(y, x) / (2*math.pi)
+            u = math.atan2(y, x) / (2*math.pi) % 1
             r = math.sqrt(x*x + y*y)
             v = (math.atan2(z, r) / math.pi + 0.5) % 1
             self.assertAllAlmostEqual(uv, [u, v])

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -97,21 +97,25 @@ class TestBasicFunctionality(utils.TestCase):
         self.assertEqual(str(Model.sphere(128)), '!sphere-128')
 
     def test_repr(self):
-        self.assertEqual(repr(Model.sphere(128)), '<Model: !sphere-128>')
+        self.assertEqual(repr(Model.sphere(128)), '<Sphere(0x935c42374d93e335)>')
 
-    def test_by_name(self):
-        self.assertIsNone(Model.by_name('!sphere-104'))
-        model = Model.sphere(104)
-        self.assertIs(Model.by_name('!sphere-104'), model)
+    def test_by_id(self):
+        self.assertIsNone(Model.by_id(0x935c42374d93e335))
+        model = Model.sphere(128)
+        self.assertIs(Model.by_id(0x935c42374d93e335), model)
 
 
 class MyModel(Model):
     @staticmethod
     def get():
-        model = Model.by_name('!mymodel')
+        model = Model.by_id(123)
         if model is None:
-            model = MyModel('!mymodel')
+            model = MyModel(123)
         return model
+
+    @property
+    def name(self):
+        return '!mymodel'
 
     def is_smooth(self):
         return False
@@ -128,10 +132,11 @@ class TestSubclassing(utils.TestCase):
     def tearDown(self):
         Model.flush_caches(0, 0)
 
-    def test_subclass_insantiation(self):
+    def test_subclass_instantiation(self):
         model = MyModel.get()
         self.assertIsInstance(model, MyModel)
         self.assertEqual(model.name, '!mymodel')
+        self.assertEqual(model.id, 123)
         self.assertIs(MyModel.get(), model)
         mesh = model.get_trimesh()
         self.assertIs(model.get_trimesh(), mesh)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -602,13 +602,13 @@ class TestBuffers(utils.TestCase):
         glctx = unittest.mock.Mock()
         objects = {}
         buffers = model.get_buffers(glctx, objects)
-        self.assertIn(model.name, objects)
-        self.assertIs(objects[model.name], buffers)
-        vertex_data = glctx.buffer.mock_calls[0].args[0]
+        self.assertIn(model.id, objects)
+        self.assertIs(objects[model.id], buffers)
+        vertex_data, = glctx.buffer.mock_calls[0].args
         self.assertEqual(vertex_data.dtype.name, 'float32')
         self.assertEqual(vertex_data.shape, (24, 8))
-        index_data = glctx.buffer.mock_calls[1].args[0]
+        index_data, = glctx.buffer.mock_calls[1].args
         self.assertEqual(index_data.dtype.name, 'int32')
         self.assertEqual(index_data.shape, (12, 3))
         model.invalidate()
-        self.assertNotIn(model.name, objects)
+        self.assertNotIn(model.id, objects)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -471,7 +471,7 @@ class TestUVRemapping(utils.TestCase):
         model = Model.box()
         mesh = model.uv_remap('sphere').get_trimesh()
         for (x, y, z), uv in zip(mesh.vertices, mesh.visual.uv):
-            u = (math.atan2(y, x) / (2*math.pi)) % 1
+            u = math.atan2(y, x) / (2*math.pi)
             r = math.sqrt(x*x + y*y)
             v = (math.atan2(z, r) / math.pi + 0.5) % 1
             self.assertAllAlmostEqual(uv, [u, v])


### PR DESCRIPTION
For programs with a very large number of instances, a lot of time is spent collecting the models. A significant amount of this seems to be the cost of building the names for the models and then looking these up in the `ModelsCache`. It would be quicker to construct numeric IDs rather than string names. This PR implements that using the `HASH_` functions from `models.pxd`.

On one of my examples, which has 60k instances of about 10 different models – including 6 or 7 that are the result of `!trim` operations – the render time goes from ~35ms per frame to ~28ms.