### PR TITLE
Calculate arrays rather than trimesh objects where possible

### DIFF
--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -25,18 +25,23 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: "3.11"
-    - name: Install dependencies
+    - name: Upgrade pip
       run: |
-        echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | sudo debconf-set-selections
-        sudo apt-get install -y mesa-utils xvfb libfontconfig1 ttf-mscorefonts-installer
-        python -m pip install --upgrade pip setuptools
-        python -m pip install cython coverage pytest
-    - name: Build in place with coverage analysis enabled
+        python -m pip install --upgrade pip
+    - name: Build package in-place with coverage analysis enabled
       run: |
         pip3 install --editable .
       env:
         FLITTER_BUILD_COVERAGE: 1
-    - name: Run tests with coverage
+    - name: Install coverage and pytest
+      run: |
+        python -m pip install coverage pytest
+    - name: Install Linux Mesa OpenGL drivers and Microsoft fonts
+      run: |
+        sudo apt-get update
+        echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | sudo debconf-set-selections
+        sudo apt-get install -y mesa-utils xvfb libfontconfig1 ttf-mscorefonts-installer
+    - name: Run all tests with coverage
       run: |
         xvfb-run coverage run --source=src -m pytest tests --ignore=tests/test_engine.py --durations=5
     - name: Generate coverage reports

--- a/.github/workflows/ci-coverage.yml
+++ b/.github/workflows/ci-coverage.yml
@@ -35,7 +35,7 @@ jobs:
         FLITTER_BUILD_COVERAGE: 1
     - name: Install coverage and pytest
       run: |
-        python -m pip install coverage pytest
+        python -m pip install cython coverage pytest
     - name: Install Linux Mesa OpenGL drivers and Microsoft fonts
       run: |
         sudo apt-get update

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -37,11 +37,6 @@ jobs:
     - name: Upgrade pip
       run: |
         python -m pip install --upgrade pip
-    - name: Install Linux build dependencies
-      if: matrix.os == 'ubuntu-latest'
-      run: |
-        sudo apt-get update
-        sudo apt-get install libasound2-dev libjack-jackd2-dev
     - name: Build and install package
       run: |
         python -m pip install .
@@ -51,6 +46,7 @@ jobs:
     - name: Install Linux Mesa OpenGL drivers and Microsoft fonts
       if: matrix.os == 'ubuntu-latest'
       run: |
+        sudo apt-get update
         echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | sudo debconf-set-selections
         sudo apt-get install -y mesa-utils xvfb libfontconfig1 ttf-mscorefonts-installer
         python -m pip install pytest-xvfb

--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -37,6 +37,11 @@ jobs:
     - name: Upgrade pip
       run: |
         python -m pip install --upgrade pip
+    - name: Install Linux build dependencies
+      if: matrix.os == 'ubuntu-latest'
+      run: |
+        sudo apt-get update
+        sudo apt-get install libasound2-dev libjack-jackd2-dev
     - name: Build and install package
       run: |
         python -m pip install .
@@ -46,7 +51,6 @@ jobs:
     - name: Install Linux Mesa OpenGL drivers and Microsoft fonts
       if: matrix.os == 'ubuntu-latest'
       run: |
-        sudo apt-get update
         echo "ttf-mscorefonts-installer msttcorefonts/accepted-mscorefonts-eula select true" | sudo debconf-set-selections
         sudo apt-get install -y mesa-utils xvfb libfontconfig1 ttf-mscorefonts-installer
         python -m pip install pytest-xvfb

--- a/docs/canvas3d.md
+++ b/docs/canvas3d.md
@@ -833,11 +833,11 @@ To load an external model use the attributes:
 will be automatically reloaded if this file changes.
 
 `repair=` ( `true` | `false` )
-: If set to `true`, attempts to *repair* the mesh by merging vertices and
-removing duplicate or degenerate faces, fixing normal directions and face
-windings, and capping holes. This can be useful if a mesh is rendering
-incorrectly or is failing with [constructive solid
-geometry](#contructive-solid-geometry) operations. Default is `false`.
+: If set to `true`, attempts to *repair* the mesh by merging duplicated vertices
+removing duplicate or degenerate faces, and fixing normal directions and face
+windings. This can be useful if a loaded mesh is rendering incorrectly or is
+failing with [constructive solid geometry](#contructive-solid-geometry)
+operations. Default is `false`.
 
 Meshes are loaded using the [**trimesh**](https://trimesh.org) library and so
 **Flitter** supports all of the file-types supported by that, which includes
@@ -882,7 +882,7 @@ will have the same number of faces, but three distinct vertices per face.
 
 For finer-grained control over shading, there is an edge snapping algorithm
 that will take a smooth-shaded model, find sharp edges and split them into
-seams. This algorithm can be controlled with the following attributes:
+seams. This algorithm can be controlled with the following attribute:
 
 `snap_edges=` `0`…`0.5`
 : This specifies the minimum edge angle (in *turns*) at which to snap. It
@@ -891,11 +891,6 @@ angle of `0` would mean that the two faces are in the same plane, `0.25` would
 mean that they are at right angles to one another. Specifying `0.5` will disable
 the algorithm completely, `0` will cause all edges to be snapped (which is
 equivalent to specifying `flat=true`).
-
-`minimum_area=` `0`…`1`
-: This specifies a minimum area for a face below which it will be ignored by the
-algorithm. This is given as a ratio of face area to total model area. If not
-specified, then all faces will be considered.
 
 A model can also be *inverted* with the attribute:
 

--- a/src/flitter/engine/control.py
+++ b/src/flitter/engine/control.py
@@ -230,6 +230,7 @@ class EngineController:
 
                 del context
                 SharedCache.clean()
+                Model.update_cache_timestamps()
 
                 self.state['_counter'] = self.counter.tempo, self.counter.quantum, self.counter.start
 

--- a/src/flitter/render/window/canvas3d.pyx
+++ b/src/flitter/render/window/canvas3d.pyx
@@ -510,8 +510,8 @@ cdef Model get_model(Node node, bint top):
         if top:
             if node.get_bool('flat', False):
                 model = model.flatten()
-            elif (snap_angle := node.get_float('snap_edges', DefaultSnapAngle if model.is_smooth() else 0.5)) < 0.5:
-                model = model._snap_edges(snap_angle, node.get_float('minimum_area', 0))
+            elif (snap_angle := node.get_float('snap_edges', DefaultSnapAngle if model.is_manifold() else 0.5)) < 0.5:
+                model = model._snap_edges(snap_angle)
             if node.get_bool('invert', False):
                 model = model.invert()
             if (mapping := node.get_str('uv_remap', None)) is not None:

--- a/src/flitter/render/window/models.pxd
+++ b/src/flitter/render/window/models.pxd
@@ -9,6 +9,9 @@ cdef double DefaultSnapAngle
 cdef int64_t DefaultSegments
 
 
+cpdef void fill_in_normals(vertices_array, faces_array)
+
+
 cdef class Model:
     cdef readonly uint64_t id
     cdef readonly double touch_timestamp

--- a/src/flitter/render/window/models.pxd
+++ b/src/flitter/render/window/models.pxd
@@ -22,7 +22,7 @@ cdef class Model:
     cpdef bint uncache(self, bint buffers)
     cpdef void unload(self)
     cpdef void check_for_changes(self)
-    cpdef bint is_smooth(self)
+    cpdef bint is_manifold(self)
     cpdef double signed_distance(self, double x, double y, double z) noexcept
     cpdef tuple build_arrays(self)
     cpdef object build_trimesh(self)
@@ -40,7 +40,7 @@ cdef class Model:
     cpdef Model flatten(self)
     cpdef Model invert(self)
     cpdef Model repair(self)
-    cdef Model _snap_edges(self, double snap_angle, double minimum_area)
+    cdef Model _snap_edges(self, double snap_angle)
     cdef Model _transform(self, Matrix44 transform_matrix)
     cdef Model _uv_remap(self, str mapping)
     cdef Model _trim(self, Vector origin, Vector normal, double smooth, double fillet, double chamfer)

--- a/src/flitter/render/window/models.pxd
+++ b/src/flitter/render/window/models.pxd
@@ -21,6 +21,7 @@ cdef class Model:
     cpdef void check_for_changes(self)
     cpdef bint is_smooth(self)
     cpdef double signed_distance(self, double x, double y, double z) noexcept
+    cpdef tuple build_arrays(self)
     cpdef object build_trimesh(self)
     cpdef object build_manifold(self)
 
@@ -28,6 +29,7 @@ cdef class Model:
     cpdef void remove_dependent(self, Model model)
     cpdef void invalidate(self)
     cpdef Vector get_bounds(self)
+    cpdef tuple get_arrays(self)
     cpdef object get_trimesh(self)
     cpdef object get_manifold(self)
     cpdef tuple get_buffers(self, object glctx, dict objects)

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -23,7 +23,7 @@ class TestPrimitives(utils.TestCase):
 
     def test_box(self):
         model = Model.box()
-        self.assertFalse(model.is_smooth())
+        self.assertFalse(model.is_manifold())
         mesh = model.get_trimesh()
         self.assertEqual(model.name, '!box')
         self.assertEqual(mesh.bounds.tolist(), [[-0.5, -0.5, -0.5], [0.5, 0.5, 0.5]])
@@ -38,7 +38,7 @@ class TestPrimitives(utils.TestCase):
         for segments in (4, DefaultSegments, 1024):
             with self.subTest(segments=segments):
                 model = Model.sphere(segments)
-                self.assertFalse(model.is_smooth())
+                self.assertFalse(model.is_manifold())
                 self.assertEqual(model.name, f'!sphere-{segments}' if segments != DefaultSegments else '!sphere')
                 mesh = model.get_trimesh()
                 self.assertEqual(mesh.bounds.tolist(), [[-1, -1, -1], [1, 1, 1]])
@@ -59,7 +59,7 @@ class TestPrimitives(utils.TestCase):
         for segments in (4, DefaultSegments, 1024):
             with self.subTest(segments=segments):
                 model = Model.cylinder(segments)
-                self.assertFalse(model.is_smooth())
+                self.assertFalse(model.is_manifold())
                 self.assertEqual(model.name, f'!cylinder-{segments}' if segments != DefaultSegments else '!cylinder')
                 mesh = model.get_trimesh()
                 self.assertEqual(mesh.bounds.tolist(), [[-1, -1, -0.5], [1, 1, 0.5]])
@@ -78,7 +78,7 @@ class TestPrimitives(utils.TestCase):
         for segments in (4, DefaultSegments, 1024):
             with self.subTest(segments=segments):
                 model = Model.cone(segments)
-                self.assertFalse(model.is_smooth())
+                self.assertFalse(model.is_manifold())
                 self.assertEqual(model.name, f'!cone-{segments}' if segments != DefaultSegments else '!cone')
                 mesh = model.get_trimesh()
                 self.assertEqual(mesh.bounds.tolist(), [[-1, -1, -0.5], [1, 1, 0.5]])
@@ -126,7 +126,7 @@ class MyModel(Model):
     def name(self):
         return '!mymodel'
 
-    def is_smooth(self):
+    def is_manifold(self):
         return False
 
     def check_for_changes(self):
@@ -181,9 +181,18 @@ class TestVector(utils.TestCase):
         self.assertAlmostEqual(mesh.volume, 0.5)
 
     def test_invalid(self):
-        self.assertIsNone(Model.vector([0, 0, 0, 0, 0, 1, 0, 1], [0, 1, 2]).get_trimesh())
-        self.assertIsNone(Model.vector([0, 0, 0, 0, 0, 1, 0, 1, 0], [0, 1]).get_trimesh())
-        self.assertIsNone(Model.vector([0, 0, 0, 0, 0, 1, 0, 1, 0], [0, 1, 3]).get_trimesh())
+        with unittest.mock.patch('flitter.render.window.models.logger') as mock_logger:
+            model = Model.vector([0, 0, 0, 0, 0, 1, 0, 1], [0, 1, 2])
+            self.assertIsNone(model.get_trimesh())
+            mock_logger.error.assert_called_with("Bad vertices vector length: {}", model.name)
+        with unittest.mock.patch('flitter.render.window.models.logger') as mock_logger:
+            model = Model.vector([0, 0, 0, 0, 0, 1, 0, 1, 0], [0, 1])
+            self.assertIsNone(model.get_trimesh())
+            mock_logger.error.assert_called_with("Bad faces vector length: {}", model.name)
+        with unittest.mock.patch('flitter.render.window.models.logger') as mock_logger:
+            model = Model.vector([0, 0, 0, 0, 0, 1, 0, 1, 0], [0, 1, 3])
+            self.assertIsNone(model.get_trimesh())
+            mock_logger.error.assert_called_with("Bad vertex index: {}", model.name)
 
 
 class TestManifoldPrimitives(utils.TestCase):
@@ -334,9 +343,9 @@ class TestStructuring(utils.TestCase):
 
     def test_flatten(self):
         self.assertEqual(Model.box().flatten().name, 'flatten(!box)')
-        self.assertFalse(Model.box().flatten().is_smooth())
+        self.assertFalse(Model.box().flatten().is_manifold())
         self.assertIs(Model.box().flatten().get_manifold(), Model.box().get_manifold())
-        self.assertFalse(Model.union(Model.box(), Model.sphere()).flatten().is_smooth())
+        self.assertFalse(Model.union(Model.box(), Model.sphere()).flatten().is_manifold())
         self.assertEqual(Model.box().flatten().flatten().name, 'flatten(!box)')
         self.assertEqual(Model.box().flatten().invert().name, 'invert(flatten(!box))')
         self.assertEqual(Model.box().flatten().repair().name, 'repair(flatten(!box))')
@@ -347,9 +356,9 @@ class TestStructuring(utils.TestCase):
 
     def test_invert(self):
         self.assertEqual(Model.box().invert().name, 'invert(!box)')
-        self.assertFalse(Model.box().invert().is_smooth())
+        self.assertFalse(Model.box().invert().is_manifold())
         self.assertIs(Model.box().invert().get_manifold(), Model.box().get_manifold())
-        self.assertTrue(Model.union(Model.box(), Model.sphere()).invert().is_smooth())
+        self.assertFalse(Model.union(Model.box(), Model.sphere()).invert().is_manifold())
         self.assertEqual(Model.box().invert().flatten().name, 'flatten(invert(!box))')
         self.assertEqual(Model.box().invert().invert().name, '!box')
         self.assertEqual(Model.box().invert().repair().name, 'invert(repair(!box))')
@@ -360,7 +369,7 @@ class TestStructuring(utils.TestCase):
 
     def test_repair(self):
         self.assertEqual(Model.box().repair().name, 'repair(!box)')
-        self.assertTrue(Model.box().repair().is_smooth())
+        self.assertFalse(Model.box().repair().is_manifold())
         self.assertIsNot(Model.box().repair().get_manifold(), Model.box().get_manifold())
         self.assertEqual(Model.box().repair().flatten().name, 'flatten(repair(!box))')
         self.assertEqual(Model.box().repair().invert().name, 'invert(repair(!box))')
@@ -372,14 +381,12 @@ class TestStructuring(utils.TestCase):
 
     def test_snap_edges(self):
         self.assertEqual(Model.box().snap_edges(0).name, 'flatten(!box)')
-        self.assertFalse(Model.box().snap_edges().is_smooth())
-        self.assertIs(Model.box().snap_edges().get_manifold(), Model.box().get_manifold())
-        self.assertFalse(Model.union(Model.box(), Model.sphere()).snap_edges().is_smooth())
+        self.assertFalse(Model.box().snap_edges().is_manifold())
+        self.assertIsNot(Model.box().snap_edges().get_manifold(), Model.box().get_manifold())
+        self.assertFalse(Model.union(Model.box(), Model.sphere()).snap_edges().is_manifold())
         self.assertEqual(Model.box().snap_edges().name, 'snap_edges(!box)')
         self.assertEqual(Model.box().snap_edges(0.05).name, 'snap_edges(!box)')
         self.assertEqual(Model.box().snap_edges(0.25).name, 'snap_edges(!box, 0.25)')
-        self.assertEqual(Model.box().snap_edges(0.05, 0.25).name, 'snap_edges(!box, 0.05, 0.25)')
-        self.assertEqual(Model.box().snap_edges(0.25, 0.25).name, 'snap_edges(!box, 0.25, 0.25)')
         self.assertEqual(Model.box().snap_edges().flatten().name, 'flatten(!box)')
         self.assertEqual(Model.box().snap_edges().invert().name, 'invert(snap_edges(!box))')
         self.assertEqual(Model.box().snap_edges().repair().name, 'snap_edges(repair(!box))')
@@ -390,8 +397,8 @@ class TestStructuring(utils.TestCase):
 
     def test_transform(self):
         self.assertEqual(Model.box().transform(Matrix44()).name, '!box')
-        self.assertFalse(Model.box().transform(self.M).is_smooth())
-        self.assertTrue(Model.union(Model.box(), Model.sphere()).transform(self.M).is_smooth())
+        self.assertFalse(Model.box().transform(self.M).is_manifold())
+        self.assertTrue(Model.union(Model.box(), Model.sphere()).transform(self.M).is_manifold())
         self.assertEqual(Model.box().transform(self.M).name, f'!box@{self.M_hash}')
         self.assertEqual(Model.box().transform(self.M).flatten().name, f'flatten(!box@{self.M_hash})')
         self.assertEqual(Model.box().transform(self.M).invert().name, f'invert(!box@{self.M_hash})')
@@ -403,9 +410,9 @@ class TestStructuring(utils.TestCase):
 
     def test_uvremap(self):
         self.assertEqual(Model.box().uv_remap('sphere').name, 'uv_remap(!box, sphere)')
-        self.assertFalse(Model.box().uv_remap('sphere').is_smooth())
+        self.assertFalse(Model.box().uv_remap('sphere').is_manifold())
         self.assertIs(Model.box().uv_remap('sphere').get_manifold(), Model.box().get_manifold())
-        self.assertTrue(Model.union(Model.box(), Model.sphere()).uv_remap('sphere').is_smooth())
+        self.assertFalse(Model.union(Model.box(), Model.sphere()).uv_remap('sphere').is_manifold())
         self.assertEqual(Model.box().uv_remap('sphere').flatten().name, 'flatten(uv_remap(!box, sphere))')
         self.assertEqual(Model.box().uv_remap('sphere').invert().name, 'invert(uv_remap(!box, sphere))')
         self.assertEqual(Model.box().uv_remap('sphere').repair().name, 'uv_remap(repair(!box), sphere)')
@@ -416,7 +423,7 @@ class TestStructuring(utils.TestCase):
 
     def test_trim(self):
         self.assertEqual(Model.box().trim(self.P, self.N).name, f'trim(!box, {self.PN_hash})')
-        self.assertTrue(Model.box().trim(self.P, self.N).is_smooth())
+        self.assertTrue(Model.box().trim(self.P, self.N).is_manifold())
         self.assertEqual(Model.box().trim(self.P, self.N).flatten().name, f'flatten(trim(!box, {self.PN_hash}))')
         self.assertEqual(Model.box().trim(self.P, self.N).invert().name, f'invert(trim(!box, {self.PN_hash}))')
         self.assertEqual(Model.box().trim(self.P, self.N).repair().name, f'trim(repair(!box), {self.PN_hash})')
@@ -433,7 +440,7 @@ class TestStructuring(utils.TestCase):
         self.assertEqual(Model.union(Model.box(), Model.sphere()).name, 'union(!box, !sphere)')
         self.assertEqual(Model.union(Model.box(), Model.sphere(), Model.box()).name, 'union(!box, !sphere)')
         self.assertEqual(Model.union(Model.box(), Model.union(Model.sphere(), Model.cylinder())).name, 'union(!box, !sphere, !cylinder)')
-        self.assertTrue(Model.union(Model.box(), Model.sphere()).is_smooth())
+        self.assertTrue(Model.union(Model.box(), Model.sphere()).is_manifold())
         self.assertEqual(Model.union(Model.box(), Model.sphere()).flatten().name, 'flatten(union(!box, !sphere))')
         self.assertEqual(Model.union(Model.box(), Model.sphere()).invert().name, 'invert(union(!box, !sphere))')
         self.assertEqual(Model.union(Model.box(), Model.sphere()).repair().name, 'union(!box, !sphere)')
@@ -449,7 +456,7 @@ class TestStructuring(utils.TestCase):
         self.assertEqual(Model.intersect(Model.box(), Model.sphere()).name, 'intersect(!box, !sphere)')
         self.assertEqual(Model.intersect(Model.box(), Model.sphere(), Model.box()).name, 'intersect(!box, !sphere)')
         self.assertEqual(Model.intersect(Model.box(), Model.intersect(Model.sphere(), Model.cylinder())).name, 'intersect(!box, !sphere, !cylinder)')
-        self.assertTrue(Model.intersect(Model.box(), Model.sphere()).is_smooth())
+        self.assertTrue(Model.intersect(Model.box(), Model.sphere()).is_manifold())
         self.assertEqual(Model.intersect(Model.box(), Model.sphere()).flatten().name, 'flatten(intersect(!box, !sphere))')
         self.assertEqual(Model.intersect(Model.box(), Model.sphere()).invert().name, 'invert(intersect(!box, !sphere))')
         self.assertEqual(Model.intersect(Model.box(), Model.sphere()).repair().name, 'intersect(!box, !sphere)')
@@ -466,7 +473,7 @@ class TestStructuring(utils.TestCase):
         self.assertIsNone(Model.difference(Model.box(), Model.sphere(), Model.box()))
         self.assertEqual(Model.difference(Model.box(), Model.difference(Model.sphere(), Model.cylinder())).name,
                          'difference(!box, difference(!sphere, !cylinder))')
-        self.assertTrue(Model.difference(Model.box(), Model.sphere()).is_smooth())
+        self.assertTrue(Model.difference(Model.box(), Model.sphere()).is_manifold())
         self.assertEqual(Model.difference(Model.box(), Model.sphere()).flatten().name, 'flatten(difference(!box, !sphere))')
         self.assertEqual(Model.difference(Model.box(), Model.sphere()).invert().name, 'invert(difference(!box, !sphere))')
         self.assertEqual(Model.difference(Model.box(), Model.sphere()).repair().name, 'difference(!box, !sphere)')
@@ -522,7 +529,7 @@ class TestTrim(utils.TestCase):
             model = model.trim((0, y/2, 0), (0, y, 0))
         for z in (-1, 1):
             model = model.trim((0, 0, z/2), (0, 0, z))
-        self.assertTrue(model.is_smooth())
+        self.assertTrue(model.is_manifold())
         mesh = model.get_trimesh()
         self.assertEqual(mesh.bounds.tolist(), [[-0.5, -0.5, -0.5], [0.5, 0.5, 0.5]])
         self.assertEqual(len(mesh.vertices), 8)
@@ -533,7 +540,7 @@ class TestTrim(utils.TestCase):
     def test_trim_to_nothing(self):
         model = Model.box()
         model = model.trim((0, 0, -1), (0, 0, 1))
-        self.assertTrue(model.is_smooth())
+        self.assertTrue(model.is_manifold())
         with unittest.mock.patch('flitter.render.window.models.logger') as mock_logger:
             manifold = model.get_manifold()
             mock_logger.warning.assert_called_with("Result of operation was empty mesh: {}", model.name)
@@ -569,6 +576,11 @@ class TestBoolean(utils.TestCase):
                          self.wrap_name('intersect(!box, !sphere)'))
         self.assertEqual(self.wrap_model(Model.difference(Model.box(), None, Model.sphere())).name,
                          self.wrap_name('difference(!box, !sphere)'))
+
+    def test_is_manifold(self):
+        self.assertTrue(self.wrap_model(Model.union(Model.box(), Model.sphere())).is_manifold())
+        self.assertTrue(self.wrap_model(Model.intersect(Model.box(), Model.sphere())).is_manifold())
+        self.assertTrue(self.wrap_model(Model.difference(Model.box(), Model.sphere())).is_manifold())
 
     def test_nested_box_union(self):
         model = self.wrap_model(Model.union(*self.nested_box_models))
@@ -646,6 +658,9 @@ class TestSdfBoolean(TestBoolean):
 class TestSdfTrim(utils.TestCase):
     def tearDown(self):
         Model.flush_caches(0, 0)
+
+    def test_is_manifold(self):
+        self.assertTrue(Model.sphere().trim((0, 0, 0), (0, 0, 1)).is_manifold())
 
     def test_trim_sphere_to_box(self):
         model = Model.sphere()

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -183,6 +183,7 @@ class TestVector(utils.TestCase):
     def test_invalid(self):
         self.assertIsNone(Model.vector([0, 0, 0, 0, 0, 1, 0, 1], [0, 1, 2]).get_trimesh())
         self.assertIsNone(Model.vector([0, 0, 0, 0, 0, 1, 0, 1, 0], [0, 1]).get_trimesh())
+        self.assertIsNone(Model.vector([0, 0, 0, 0, 0, 1, 0, 1, 0], [0, 1, 3]).get_trimesh())
 
 
 class TestManifoldPrimitives(utils.TestCase):


### PR DESCRIPTION
Adds new `get_arrays()` and `build_arrays()` and fills these in for the obvious operations and primitives. Also, only do a full collection if a  trimesh object is released and separate updating cache timestamps from  cache clearing. Fixes #71 - or, at least, improves it. In a further  positive, the new normals calculation function is faster than the  trimesh one.