### PR TITLE
Updates for Python 3.14

### DIFF
--- a/.github/workflows/ci-test.yml
+++ b/.github/workflows/ci-test.yml
@@ -20,7 +20,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         os: [ubuntu-latest, ubuntu-24.04-arm, windows-latest, macos-15-intel, macos-15]
         include:
         - os: macos-15-intel

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ classifiers = [
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Environment :: Console",
   "Environment :: GPU",
   "Environment :: MacOS X",


### PR DESCRIPTION
For the moment, this is a holding PR until we have all of the dependencies.

Currently missing 3.14 builds are:

- [x] `skia-python` - https://pypi.org/project/skia-python/?filename=cp314#files
- [ ] `rtmidi2` - https://pypi.org/project/rtmidi2/?filename=cp314#files
- [x] `manifold3d` - https://pypi.org/project/manifold3d/?filename=cp314#files
- [ ] `moderngl` - https://pypi.org/project/moderngl/?filename=cp314#files